### PR TITLE
PresenciaSetmanal i Agrupaments

### DIFF
--- a/aula/apps/alumnes/gestioGrups.py
+++ b/aula/apps/alumnes/gestioGrups.py
@@ -51,47 +51,6 @@ def grupsAgrupament(grup):
     q_Agrup=llistaIdsAgrupament(grup.id)
     return Grup.objects.filter(id__in = q_Agrup).filter(alumne__isnull = False).distinct()
 
-def llistaIdsAgrupamentHor(grupid):
-    '''Determina tots els grups que reben alumnes de grupid, segons els agrupaments
-    
-    grupid id del grup que volem els seus agrupaments
-    Retorna una llista que conté tots els id de grup a on el grup indicat aporta alumnes
-
-    '''
-    
-    llista=set()
-    q_Agrup=Agrupament.objects.filter(grup_alumnes=grupid).values('grup_horari').distinct()
-    if not(q_Agrup.exists()):
-        # No hi ha agrupament
-        return { grupid }
-    if q_Agrup.count()==1 and q_Agrup.first()['grup_horari']==grupid:
-        # Agrupament és el mateix grup
-        return { grupid }
-    # Agrupaments dels altres grups
-    for g in q_Agrup:
-        if (g['grup_horari']==grupid):
-            # Si és el mateix grup, s'afegeix sense fer més recerca
-            llista.add(grupid)
-        else:
-            # Es continua la recerca
-            llista.update(llistaIdsAgrupamentHor(g['grup_horari']))
-    return llista
-
-def grupsAgrupamentTots(grup):
-    '''Retorna queryset dels grups relacionats en qualsevol agrupament amb grup.
-
-    grup del que volem els seus agrupaments
-    Retorna queryset amb els grups trobats
-    
-    '''
-    
-    q_Agrup1=llistaIdsAgrupament(grup.id)
-    q_Agrup2=llistaIdsAgrupamentHor(grup.id)
-    q_Agrup1.update(q_Agrup2)
-    return Grup.objects.filter(id__in = q_Agrup1).distinct()
-
-
-
 #  amorilla@xtec.cat
 #  He canviat la ubicació d'aquesta funció.
 #  Amb els canvis realitzats donava error en el migrate (referència circular)

--- a/aula/apps/extSaga/sincronitzaSaga.py
+++ b/aula/apps/extSaga/sincronitzaSaga.py
@@ -63,6 +63,7 @@ def sincronitza(f, user = None):
         a=Alumne()
         a.ralc = ''
         a.telefons = ''
+        dni = ''
         #a.tutors = ''
         #a.correu_tutors = ''
 
@@ -125,6 +126,8 @@ def sincronitza(f, user = None):
                 a.adreca = unicode(value,'iso-8859-1')
             if columnName.endswith( u"_CP"):
                 a.cp = unicode(value,'iso-8859-1')
+            if columnName.endswith( u"_DOC. IDENTITAT"):
+                dni = unicode(value,'iso-8859-1')
 
 
         if not (trobatGrupClasse and trobatNom and trobatDataNeixement and trobatRalc):
@@ -132,6 +135,11 @@ def sincronitza(f, user = None):
 
 
         alumneDadesAnteriors = None
+        if not bool(a.ralc) or a.ralc=='':
+            autoRalc, _ = ParametreSaga.objects.get_or_create( nom_parametre = 'autoRalc' )
+            if bool(autoRalc.valor_parametre):
+                a.ralc= autoRalc.valor_parametre + dni[-9:]
+
         try:
             q_mateix_ralc = Q( ralc = a.ralc ) # & Q(  grup__curs__nivell = a.grup.curs.nivell )
 

--- a/aula/apps/presencia/views.py
+++ b/aula/apps/presencia/views.py
@@ -282,10 +282,11 @@ def passaLlista(request, pk):
                      .order_by('hora_fi')
                      .last()
                       )
-    esUltimaHora = impartir.reserva_id == ultimaReserva.id
-    if esUltimaHora:
-        msg = u" Atenció: És última hora en aquesta aula. Recorda't de tancar finestres, baixar persianes, pujar cadires, etc."
-        messages.error(request, SafeText(msg))
+    if ultimaReserva is not None:
+        esUltimaHora = impartir.reserva_id == ultimaReserva.id
+        if esUltimaHora:
+            msg = u" Atenció: És última hora en aquesta aula. Recorda't de tancar finestres, baixar persianes, pujar cadires, etc."
+            messages.error(request, SafeText(msg))
 
     url_next = '/presencia/mostraImpartir/%d/%d/%d/' % (
         impartir.dia_impartir.year,

--- a/aula/apps/presenciaSetmanal/forms.py
+++ b/aula/apps/presenciaSetmanal/forms.py
@@ -1,0 +1,15 @@
+# This Python file uses the following encoding: utf-8
+from django import forms as forms
+from aula.apps.alumnes.models import Grup
+
+#-------------------------------------------------------------------------------------------------------------
+class EscollirGrupForm(forms.Form):
+
+    grup_list = forms.ModelChoiceField(label=u'Grup d\'alumnes', queryset=None, required = True,)
+    nomesPropies = forms.BooleanField(label=u'Només hores pròpies', required = False)
+
+    def __init__(self, professor, *args, **kwargs):
+        super(EscollirGrupForm, self).__init__(*args, **kwargs)
+        self.fields['grup_list'].queryset = Grup.objects.filter(horari__professor = professor).distinct()
+
+    

--- a/aula/apps/presenciaSetmanal/templates/presenciaSetmanal/detallgrup.html
+++ b/aula/apps/presenciaSetmanal/templates/presenciaSetmanal/detallgrup.html
@@ -180,9 +180,9 @@ input.botoSuperior { width: 20px; height: 14px; vertical-align:top; border: 0; b
         <!-- Títols i capçaleres -->
         <td>
             <p>Setmana del {{monday_date}}</p>
-            <a href="/presenciaSetmanal/{{grup.id}}/{{previous_date}}" name="previousweek">&lt; &lt; Ant</a>
+            <a href="/presenciaSetmanal/{{grup.id}}/{{previous_date}}/{{nomesPropies}}" name="previousweek">&lt; &lt; Ant</a>
             |
-            <a href="/presenciaSetmanal/{{grup.id}}/{{next_date}}" name="nextweek">Seg &gt; &gt;</a>
+            <a href="/presenciaSetmanal/{{grup.id}}/{{next_date}}/{{nomesPropies}}" name="nextweek">Seg &gt; &gt;</a>
         </td>
         {% for hora in hores %}
         <td valign="top" class="celaMatriu">

--- a/aula/apps/presenciaSetmanal/urls.py
+++ b/aula/apps/presenciaSetmanal/urls.py
@@ -6,8 +6,9 @@ urlpatterns = [
     #Exemple: presenciaPiolin
     url(r'^$', views.index, name='aula__presencia_setmanal__index'),
     #Exemple: presenciaPiolin/5
-    url(r'^(?P<grup_id>\d+)/(?P<dataReferenciaStr>.*)/$', views.detallgrup, name='aula__presencia_setmanal__detallgrup_data'),
+    url(r'^(?P<grup_id>\d+)/(?P<dataReferenciaStr>.*)/(?P<nomesPropies>.*)/$', views.detallgrup, name='aula__presencia_setmanal__detallgrup_data'),
     url(r'^(?P<grup_id>\d+)/$', views.detallgrup, name='aula__presencia_setmanal__detallgrup'),
+
 
     url(r'modificaEstatControlAssistencia/(?P<codiEstat>.*)/(?P<idAlumne>\d+)/(?P<idImpartir>\d+)$',
         views.modificaEstatControlAssistencia),

--- a/aula/apps/presenciaSetmanal/views.py
+++ b/aula/apps/presenciaSetmanal/views.py
@@ -1,19 +1,15 @@
 # This Python file uses the following encoding: utf-8
 import datetime
-import logging, traceback, pprint
-from django.shortcuts import  get_object_or_404, render
-from django.http import HttpResponse, HttpRequest
+from django.shortcuts import  render
+from django.http import HttpResponse
 from django.core.exceptions import ValidationError, NON_FIELD_ERRORS
 from django.utils.datetime_safe import date
-from django.template import RequestContext, loader
-from aula.apps.tutoria.forms import seguimentTutorialForm
 from aula.apps.usuaris.models import User2Professor, Accio
 from collections import OrderedDict
 from django.conf import settings
 
 #auth
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.models import User
 from aula.utils.tools import getImpersonateUser
 from aula.utils.decorators import group_required
 
@@ -21,9 +17,6 @@ from aula.utils.decorators import group_required
 from aula.apps.presencia.models import Impartir, ControlAssistencia, EstatControlAssistencia
 from aula.apps.presenciaSetmanal.forms import EscollirGrupForm
 from aula.apps.alumnes.models import Grup
-from aula.apps.usuaris.models import User2Professor, Professor
-from aula.apps.alumnes.gestioGrups import grupsAgrupamentTots
-from libpasteurize.fixes.fix_kwargs import _else_template
 
 CONST_ERROR_CODE = '_'
 
@@ -190,7 +183,6 @@ def detallgrup(request, grup_id, dataReferenciaStr='', nomesPropies=None):
     ddies = _recompteHores(hores)
 
     #assert False, ddies
-    template = loader.get_template('presenciaSetmanal/detallgrup.html')
     context ={
         'mvisualitza': mvisualitza,
         'ddies': ddies,
@@ -240,7 +232,6 @@ def modificaEstatControlAssistencia(request, codiEstat, idAlumne, idImpartir):
         impartir.save()
 
         #Log
-        from aula.apps.usuaris.models import Accio
         Accio.objects.create(
             tipus='PL',
             usuari=user,

--- a/aula/apps/presenciaSetmanal/views.py
+++ b/aula/apps/presenciaSetmanal/views.py
@@ -19,8 +19,11 @@ from aula.utils.decorators import group_required
 
 #Models
 from aula.apps.presencia.models import Impartir, ControlAssistencia, EstatControlAssistencia
+from aula.apps.presenciaSetmanal.forms import EscollirGrupForm
 from aula.apps.alumnes.models import Grup
 from aula.apps.usuaris.models import User2Professor, Professor
+from aula.apps.alumnes.gestioGrups import grupsAgrupamentTots
+from libpasteurize.fixes.fix_kwargs import _else_template
 
 CONST_ERROR_CODE = '_'
 
@@ -28,25 +31,32 @@ CONST_ERROR_CODE = '_'
 @login_required
 @group_required(['professors'])
 def index(request):
-    # type: (HttpRequest) -> HttpResponse
-    
+
     #Obtenir l'usuari actual.
     credentials = getImpersonateUser(request)
     (user, _ ) = credentials
     professor = User2Professor( user )
-
-    #Relació inversa segons el manual funciona, similar a la relació blog - entradaBlog.
-    #Veure Spanning multi-valued relationships (guia de models)
-    grup_list = Grup.objects.filter(horari__professor = professor).distinct()
-    template = loader.get_template('presenciaSetmanal/index.html')
-    context =  {'grup_list': grup_list }
-    #return HttpResponse(repr(grup_list[0]))
-    return render(request, "presenciaSetmanal/index.html",context)
     
+    if request.method == 'POST':
+        form = EscollirGrupForm(professor, request.POST)
+        if form.is_valid():
+            grup=form.cleaned_data['grup_list']
+            nomesPropies=form.cleaned_data['nomesPropies']
+            if nomesPropies: nomesPropies='True'
+            else: nomesPropies='False'
+            return detallgrup(request, grup.id, dataReferenciaStr='', nomesPropies=nomesPropies)
+    else:
+        form = EscollirGrupForm(professor)
+    return render(
+                request,
+                'form.html', 
+                {'form': form, 
+                 },
+                )
 
 @login_required
 @group_required(['professors'])
-def detallgrup(request, grup_id, dataReferenciaStr=''):
+def detallgrup(request, grup_id, dataReferenciaStr='', nomesPropies=None):
     '''
     Veure els alumnes que entren dins les hores d'un grup i permetre modificar-ne l'estat.
     :param request:
@@ -54,6 +64,11 @@ def detallgrup(request, grup_id, dataReferenciaStr=''):
     :param string dataReferenciaStr:La data de referència a partir de la qual tindrem la setmana.
     :return:
     '''
+    #Obtenir l'usuari actual.
+    credentials = getImpersonateUser(request)
+    (user, _ ) = credentials
+    professor = User2Professor( user )
+    
     grup = Grup.objects.get(id=grup_id)
 
     dataRef = date.today()
@@ -71,11 +86,12 @@ def detallgrup(request, grup_id, dataReferenciaStr=''):
     #Consultar els estats del control d'assistencia
     estats = LlistaEstats()
 
-    #Seleccionar el calendari impartir.
-    hores = Impartir.objects.filter(
-        horari__grup_id=grup_id,
-        dia_impartir__range=[dillunsSetmana, divendresSetmana]).order_by(
-            'horari__dia_de_la_setmana__n_dia_ca', 'horari__hora__hora_inici')
+    # Llista amb els alumnes que el professor té al control d'assistència en aquest grup.
+    llalumnes=ControlAssistencia.objects.filter(
+        impartir__horari__grup_id=grup_id,
+        impartir__horari__professor_id=professor,
+        impartir__dia_impartir__range=[dillunsSetmana, divendresSetmana],
+        ).values('alumne')
 
     #Expresssio per consultar els l'assistencia dels alumnes entre una data d'inici i una data de fi.
     '''sqlExpr = \
@@ -97,11 +113,25 @@ def detallgrup(request, grup_id, dataReferenciaStr=''):
     assistencies = ControlAssistencia.objects.raw(sqlExpr)
     '''
 
-    assistencies=ControlAssistencia.objects.filter( 
-        impartir__dia_impartir__gte=dillunsSetmana, 
-        impartir__dia_impartir__lte=divendresSetmana,  
-        impartir__horari__grup_id=grup_id,
-    ).order_by('alumne__cognoms', 'impartir__horari__dia_de_la_setmana__n_dia_ca', 'impartir__horari__hora__hora_inici')
+    if nomesPropies is not None and nomesPropies=='True':
+        # Selecciona totes les assistències dels alumnes amb aquest professor
+        assistencies=ControlAssistencia.objects.filter( 
+            impartir__horari__professor_id=professor,
+            impartir__dia_impartir__range=[dillunsSetmana, divendresSetmana],  
+            alumne_id__in=llalumnes,
+        ).order_by('alumne__cognoms', 'impartir__horari__dia_de_la_setmana__n_dia_ca', 'impartir__horari__hora__hora_inici')
+    else:
+        # Selecciona totes les assistències dels alumnes encara que no siguin del professor
+        assistencies=ControlAssistencia.objects.filter( 
+            impartir__dia_impartir__range=[dillunsSetmana, divendresSetmana],  
+            alumne_id__in=llalumnes,
+        ).order_by('alumne__cognoms', 'impartir__horari__dia_de_la_setmana__n_dia_ca', 'impartir__horari__hora__hora_inici')
+
+    #Selecciona les hores de les assistències trobades
+    hores = Impartir.objects.filter(
+        pk__in=assistencies.values('impartir')).order_by(
+            'horari__dia_de_la_setmana__n_dia_ca', 'horari__hora__hora_inici')
+    
 
     # mah = Matriu alumnes, hores.
     mah = {}
@@ -169,7 +199,8 @@ def detallgrup(request, grup_id, dataReferenciaStr=''):
         'next_date': nextDate.strftime('%Y%m%d'),
         'previous_date': previousDate.strftime('%Y%m%d'),
         'monday_date': dillunsSetmana.strftime('%d/%m/%Y'),
-        'grup': grup}
+        'grup': grup,
+        'nomesPropies':nomesPropies}
 
     return render(request, 'presenciaSetmanal/detallgrup.html', context)
 


### PR DESCRIPTION
Permet escollir veure horari complet de tots els alumnes o només les
hores pròpies del professor. S'ha adaptat als agrupaments que es fan
servir per determinar els desdoblaments en Untis.
Es modifica el mecanisme de selecció de l'horari. En cicles formatius es
podia donar el cas d'alumnes que assisteixen a classe de primer curs
però també fan classe a segon curs, això podia provocar que no es
veiessin tots els alumnes o totes les assignatures. Ara selecciona
l'horari tenint en compte la llista d'assistència creada del professor i
mostra totes les assignatures de tots els alumnes de la llista encara
que no estiguin matriculats al grup.

Afegit dni en l'importació de Saga. Nou paràmetre a "Paràmetres Saga"
nom_parametre: autoRalc
Es fa servir per a casos d'alumnes que no tenen ralc, com els cursos de
CAM i CIS. Crea un ralc automàtic amb el paràmetre i el dni. Si no
existeix el paràmetre aleshores no fa canvis al ralc.
Exemples:
Paràmetre autoRalc=  'RALC'
dni=11111111H  -->  ralc=RALC11111111H
dni=22222222J  -->  ralc=RALC22222222J

En el cas d'última hora comprova si existeixen les reserves. Evita error
si no s'ha assignat aula.