### PR TITLE
Reserva aula en impartició sense reserva inicial

### DIFF
--- a/aula/apps/presencia/regeneraImpartir.py
+++ b/aula/apps/presencia/regeneraImpartir.py
@@ -99,16 +99,15 @@ class regeneraThread(Thread):
                                 aula_horari = horari.aula.pk if horari.aula else -1
                                 aula_impartir = impartir_modificat.reserva.aula.pk if impartir_modificat.reserva else -1
                                 canvi_aula = ( aula_horari != aula_impartir )
-                                if ( canvi_aula and 
-                                     impartir_modificat.reserva and 
-                                     not impartir_modificat.reserva.es_reserva_manual ):
-                                    fake_l4_credentials = (None, True)
-                                    impartir_modificat.reserva.credentials = fake_l4_credentials
-                                    impartir_modificat.reserva.delete()
-                                    impartir_modificat.reserva = None
-                                    impartir_modificat.reserva_id = None                                    
+                                if canvi_aula:
+                                    if (impartir_modificat.reserva and
+                                     not impartir_modificat.reserva.es_reserva_manual):
+                                        fake_l4_credentials = (None, True)
+                                        impartir_modificat.reserva.credentials = fake_l4_credentials
+                                        impartir_modificat.reserva.delete()
+                                        impartir_modificat.reserva = None
+                                        impartir_modificat.reserva_id = None
                                     impartir_modificat.save()
-
                         else:
                             Impartir.objects.filter( dia_impartir = dia, horari = horari ).delete()
                     else:


### PR DESCRIPTION
Es pot donar el cas (segurament al començament del curs) en que es faci una càrrega d'horaris i a alguna impartició/reunió no s'hagi decidit encara en quina aula es realitzarà. 
Per tant es carregarà la impartició/reunió (professor, data i hora concreta) però no s'associa a cap aula.
Seguidament (al llarg del curs) es decideix a quina aula s'haurà de fer la impartició/reunió i es torna a carregar horaris.
El procés de regeneració d'imparticions, només guardava la impartició (creant així la reserva d'aula) si hi havia reserva anterior. Com que no hi havia, seguia sense crear la reserva d'aula.

S'ha modificat per tal que si es fa una nova càrrega d'horaris es tingui en compte la problemàtica.