### PR TITLE
Issue 117: QuerySetPaginator deprecated

### DIFF
--- a/aula/urls.py
+++ b/aula/urls.py
@@ -9,6 +9,7 @@ from django.contrib.auth.views import PasswordChangeView
 from django.views.static import serve
 
 admin.autodiscover()
+admin.site.enable_nav_sidebar = False
 
 import os.path
 import private_storage.urls

--- a/aula/utils/my_paginator.py
+++ b/aula/utils/my_paginator.py
@@ -1,14 +1,13 @@
 #http://djangosnippets.org/snippets/773/
 import math
 from django.core.paginator import \
-    Paginator, QuerySetPaginator, Page, InvalidPage
+    Paginator, Page, InvalidPage
 from functools import reduce
 
 __all__ = (
     'InvalidPage',
     'ExPaginator',
     'DiggPaginator',
-    'QuerySetDiggPaginator',
 )
 
 class ExPaginator(Paginator):
@@ -272,9 +271,6 @@ class DiggPage(Page):
                             " ".join(list(map(str, self.leading_range))),
                             " ".join(list(map(str, self.main_range))),
                             " ".join(list(map(str, self.trailing_range)))]))
-
-class QuerySetDiggPaginator(DiggPaginator, QuerySetPaginator):
-    pass
 
 if __name__ == "__main__":
     import doctest


### PR DESCRIPTION
Adapta per Django 3.1 i django-tables2 2.3.2
S'ha d'actualitzar l'entorn virtual i fer migrate
```bash
cd carpeta-github-djau
git pull
source venv/bin/activate
pip3 install -r requirements.txt --upgrade
python manage.py migrate
```
Closes: #117