### PR TITLE
Descàrrega llista de contactes

### DIFF
--- a/aula/apps/alumnes/views.py
+++ b/aula/apps/alumnes/views.py
@@ -736,21 +736,30 @@ def llistaAlumnescsv( request ):
     """
     Generates an Excel spreadsheet for review by a staff member.
     """
-    llistaAlumnes = Alumne.objects.order_by('cognoms','nom')
+    ara = datetime.now()
+    q_no_es_baixa = Q(data_baixa__gt = ara ) | Q(data_baixa__isnull = True )
+  
+    llistaAlumnes = Alumne.objects.filter(q_no_es_baixa).order_by('grup__descripcio_grup','cognoms','nom')
     
     dades = [ [e.ralc, 
                (unicode( e.grup ) + ' - ' + e.cognoms + ', ' + e.nom) , 
                e.grup, 
+               e.cognoms,
+               e.nom, 
                e.user_associat.username, 
                e.correu,
                e.rp1_correu, 
                e.rp2_correu,
                e.correu_relacio_familia_mare,
                e.correu_relacio_familia_pare,
-               e.correu_tutors ] for e in llistaAlumnes]
+               e.correu_tutors,
+               e.user_associat.last_login,
+               e.user_associat.is_active,
+               (bool(e.correu_relacio_familia_pare) or bool(e.correu_relacio_familia_mare)) ] for e in llistaAlumnes]
     
-    capcelera = [ 'ralc', 'alumne', 'grup', 'username', 'correu', 'rp1_correu', 'rp2_correu', 
-                 'correu_relacio_mare', 'correu_relacio_pare', 'correu_tutors' ]
+    capcelera = [ 'ralc', 'alumne', 'grup', 'cognoms', 'nom', 'username', 'correu', 'rp1_correu', 'rp2_correu', 
+                 'correu_relacio_mare', 'correu_relacio_pare', 'correu_tutors',
+                 'last_login', 'usuari actiu', 'correus OK' ]
 
     template = loader.get_template("export.csv")
     context = {

--- a/aula/apps/extEsfera/sincronitzaEsfera.py
+++ b/aula/apps/extEsfera/sincronitzaEsfera.py
@@ -230,9 +230,10 @@ def sincronitza(f, user = None):
     #
     # Els alumnes de Saga no s'han de tenir en compte per fer les baixes
     AlumnesDeSaga = Alumne.objects.exclude(grup__curs__nivell__in=nivells)
-    AlumnesDeSaga.update(estat_sincronitzacio='')
-
-#     #Els alumnes que hagin quedat a PRC és que s'han donat de baixa:
+    # Es canvia estat PRC a ''. No modifica DEL ni MAN
+    AlumnesDeSaga.filter( estat_sincronitzacio__exact = 'PRC' ).update(estat_sincronitzacio='')
+    
+    #Els alumnes que hagin quedat a PRC és que s'han donat de baixa:
     AlumnesDonatsDeBaixa = Alumne.objects.filter( estat_sincronitzacio__exact = 'PRC' )
     AlumnesDonatsDeBaixa.update(
                             data_baixa = date.today(),

--- a/aula/apps/extSaga/sincronitzaSaga.py
+++ b/aula/apps/extSaga/sincronitzaSaga.py
@@ -241,7 +241,9 @@ def sincronitza(f, user = None):
 
     # Els alumnes d'Esfer@ no s'han de tenir en compte per fer les baixes
     AlumnesDeEsfera = Alumne.objects.exclude(grup__curs__nivell__in=nivells)
-    AlumnesDeEsfera.update(estat_sincronitzacio='')
+    # Es canvia estat PRC a ''. No modifica DEL ni MAN
+    AlumnesDeEsfera.filter( estat_sincronitzacio__exact = 'PRC' ).update(estat_sincronitzacio='')
+    
     #Els alumnes que hagin quedat a PRC és que s'han donat de baixa:
     AlumnesDonatsDeBaixa = Alumne.objects.filter( estat_sincronitzacio__exact = 'PRC' )
     AlumnesDonatsDeBaixa.update(


### PR DESCRIPTION
Canvis a Coord.Alumnes/Llista completa.
Ara no inclou alumnes de baixa.
Ordena per grup, cognoms i nom.
Afegeix noves columnes:
cognoms, nom, last_login, usuari_actiu, correus OK (indica si s'ha
informat de com a mínim un correu de relació amb la família).