### PR TITLE
Afegir Presència Online

### DIFF
--- a/aula/apps/BI/utils.py
+++ b/aula/apps/BI/utils.py
@@ -264,7 +264,7 @@ def fact_controls( n = -1 , flag_impersona = False ):
         nDeClasses = 1 if element.estat is not None else 0
         element_row.append( nDeClasses )
         
-        nAssistencies = 1 if element.estat is not None and element.estat.codi_estat in ( 'P','R') else 0
+        nAssistencies = 1 if element.estat is not None and element.estat.codi_estat in ( 'P','R','O') else 0
         element_row.append( nAssistencies )
         
         nFaltesTotes = 1 if element.estat is not None and element.estat.codi_estat in ( 'F','J') else 0
@@ -403,7 +403,7 @@ def dades_dissociades( element ):
 def CalculaFalta( element ):
 
     if element and element.estat is not None:
-        if element.estat.codi_estat in ( 'P','R'):
+        if element.estat.codi_estat in ( 'P','R','O'):
             esFalta = 'Present' 
         else:
             esFalta = 'Absent'
@@ -416,6 +416,8 @@ def PresenciaQuerySet( qs ):
     if qs is not None and qs.filter( estat__isnull = False  ).exists():
         if qs.filter( estat__codi_estat__in = ['P','R'] ):
             esFaltaAnterior = 'Present'
+        elif qs.filter( estat__codi_estat__in = ['O'] ):
+            esFaltaAnterior = 'Online'
         else:
             esFaltaAnterior = 'Absent'
     else:

--- a/aula/apps/presencia/reports.py
+++ b/aula/apps/presencia/reports.py
@@ -87,7 +87,7 @@ def alertaAssitenciaReport( data_inici, data_fi, nivell, tpc , ordenacio ):
         # té en compte tots els dies encara que no s'hagi passat llista
         q_p = q_controls.order_by().values_list( 'id','alumne__id' ).distinct()
     else:
-        q_p = q_controls.filter( estat__codi_estat__in = ('P','R' ) ).order_by().values_list( 'id','alumne__id' ).distinct()
+        q_p = q_controls.filter( estat__codi_estat__in = ('P','R','O' ) ).order_by().values_list( 'id','alumne__id' ).distinct()
 
     q_j = q_controls.filter( estat__codi_estat = 'J' ).order_by().values_list( 'id','alumne__id' ).distinct()
     q_f = q_controls.filter( estat__codi_estat = 'F' ).order_by().values_list( 'id','alumne__id' ).distinct()
@@ -195,7 +195,7 @@ def indicadorAbsentisme( data_inici, data_fi, nivell, tpc, recerca):
         # té en compte tots els dies encara que no s'hagi passat llista
         q_p = q_controls.values('alumne__id').annotate(total=Count('id'), faltes=Count(Case(When(estat__codi_estat__in = recerca, then=1),output_field=IntegerField())))
     else:
-        q_p = q_controls.values('alumne__id').annotate(total=Count(Case(When(estat__codi_estat__in = ('J','F','P','R' ), then=1),output_field=IntegerField())), faltes=Count(Case(When(estat__codi_estat__in = recerca, then=1),output_field=IntegerField())))
+        q_p = q_controls.values('alumne__id').annotate(total=Count(Case(When(estat__codi_estat__in = ('J','F','P','R','O' ), then=1),output_field=IntegerField())), faltes=Count(Case(When(estat__codi_estat__in = recerca, then=1),output_field=IntegerField())))
 
     quantitat=q_p.count()
     # Calcula el percentatge d'absentisme per alumne i compta els que superen el límit indicat

--- a/aula/apps/presencia/rpt_faltesAssistenciaEntreDatesGrup.py
+++ b/aula/apps/presencia/rpt_faltesAssistenciaEntreDatesGrup.py
@@ -111,9 +111,9 @@ def faltesAssistenciaEntreDatesGrupRpt(
         #-present--------------------------------------------
         if settings.CUSTOM_NO_CONTROL_ES_PRESENCIA:
             # té en compte tots els dies encara que no s'hagi passat llista
-            p = controls.filter( alumne = alumne).filter(Q(estat__codi_estat = 'P') | Q(estat__codi_estat__isnull=True) ).distinct().count()
+            p = controls.filter( alumne = alumne).filter(Q(estat__codi_estat__in=['P', 'O']) | Q(estat__codi_estat__isnull=True) ).distinct().count()
         else:
-            p = controls.filter( alumne = alumne, estat__codi_estat = 'P' ).distinct().count()
+            p = controls.filter( alumne = alumne, estat__codi_estat__in=['P', 'O']).distinct().count()
         camp = tools.classebuida()
         camp.contingut = unicode(p) 
         filera.append(camp)
@@ -290,7 +290,7 @@ def alertaAssitenciaReport( data_inici, data_fi, nivell, tpc ):
                    left outer join 
                    control_assistencia p
                        on ( 
-                           p.id_estat in ( select id_estat from estat_control_assistencia where codi_estat in ('P','R' ) ) and
+                           p.id_estat in ( select id_estat from estat_control_assistencia where codi_estat in ('P','R','O' ) ) and
                            p.id_control_assistencia = ca.id_control_assistencia )
 
                    left outer join 

--- a/aula/apps/presencia/rpt_faltesAssistenciaEntreDatesProfessor.py
+++ b/aula/apps/presencia/rpt_faltesAssistenciaEntreDatesProfessor.py
@@ -130,9 +130,9 @@ def faltesAssistenciaEntreDatesProfessorRpt(
         #-present--------------------------------------------
         if settings.CUSTOM_NO_CONTROL_ES_PRESENCIA:
             # té en compte tots els dies encara que no s'hagi passat llista
-            p = controls.filter( alumne = alumne).filter(Q(estat__codi_estat = 'P') | Q(estat__codi_estat__isnull=True) ).distinct().count()
+            p = controls.filter( alumne = alumne).filter(Q(estat__codi_estat__in = ['P','O']) | Q(estat__codi_estat__isnull=True) ).distinct().count()
         else:
-            p = controls.filter( alumne = alumne, estat__codi_estat = 'P' ).distinct().count()
+            p = controls.filter( alumne = alumne, estat__codi_estat__in = ['P','O'] ).distinct().count()
         camp = tools.classebuida()
         camp.contingut = unicode(p) 
         filera.append(camp)
@@ -317,7 +317,7 @@ def alertaAssitenciaReport( data_inici, data_fi, nivell, tpc ):
                    left outer join 
                    control_assistencia p
                        on ( 
-                           p.id_estat in ( select id_estat from estat_control_assistencia where codi_estat in ('P','R' ) ) and
+                           p.id_estat in ( select id_estat from estat_control_assistencia where codi_estat in ('P','R','O' ) ) and
                            p.id_control_assistencia = ca.id_control_assistencia )
 
                    left outer join 

--- a/aula/apps/presencia/templates/passaLlista.html
+++ b/aula/apps/presencia/templates/passaLlista.html
@@ -103,6 +103,13 @@
                   $('#rad_id_{{f.prefix}}-estat_0').prop("checked", false);
                   $('#label_id_{{f.prefix}}-estat_1').addClass('active');
                   $('#rad_id_{{f.prefix}}-estat_1').prop("checked", true);
+				{% elif f.hora_anterior == 2  %}
+				  $('#label_id_{{f.prefix}}-estat_0').removeClass('active');
+                  $('#rad_id_{{f.prefix}}-estat_0').prop("checked", false);
+                  $('#label_id_{{f.prefix}}-estat_1').removeClass('active');
+                  $('#rad_id_{{f.prefix}}-estat_1').prop("checked", false);
+                  $('#label_id_{{f.prefix}}-estat_4').addClass('active');
+                  $('#rad_id_{{f.prefix}}-estat_4').prop("checked", true);
                 {% endif %}
               }
             {% endfor %}

--- a/aula/apps/presencia/views.py
+++ b/aula/apps/presencia/views.py
@@ -399,7 +399,9 @@ def passaLlista(request, pk):
             # 0 = present #1 = Falta
             d = dades_dissociades(form.instance)
             form.hora_anterior = (0 if d['assistenciaaHoraAnterior'] == 'Present' else
-                                  1 if d['assistenciaaHoraAnterior'] == 'Absent' else None)
+                                  1 if d['assistenciaaHoraAnterior'] == 'Absent' else
+                                  2 if d['assistenciaaHoraAnterior'] == 'Online' else None)
+            print (form.hora_anterior)
             prediccio, pct = predictTreeModel(d)
             form.prediccio = (0 if prediccio == 'Present' else
                               1 if prediccio == 'Absent' else  None)

--- a/aula/apps/relacioFamilies/views.py
+++ b/aula/apps/relacioFamilies/views.py
@@ -433,7 +433,7 @@ def elMeuInforme( request, pk = None ):
 
     #----Assistencia --------------------------------------------------------------------
     if detall in ['all', 'assistencia']:
-        controls = alumne.controlassistencia_set.exclude( estat__codi_estat = 'P' 
+        controls = alumne.controlassistencia_set.exclude( estat__codi_estat__in = ['P','O']
                                                               ).filter(  
                                                         estat__isnull=False                                                          
                                                             )

--- a/aula/apps/tutoria/reports.py
+++ b/aula/apps/tutoria/reports.py
@@ -66,9 +66,9 @@ def reportFaltesIncidencies( dataInici, dataFi , alumnes_informe = [], alumnes_r
                     q_desde = Q( impartir__dia_impartir__gte = dataInici )
                     q_finsa = Q( impartir__dia_impartir__lte = dataFi )
                     if settings.CUSTOM_NO_CONTROL_ES_PRESENCIA:
-                        q_presencia = Q( estat__codi_estat = 'P' ) | Q( estat__codi_estat__isnull=True )
+                        q_presencia = Q( estat__codi_estat__in = ['P','O'] ) | Q( estat__codi_estat__isnull=True )
                     else:
-                        q_presencia = Q( estat__codi_estat = 'P' )
+                        q_presencia = Q( estat__codi_estat__in = ['P','O'] )
                     q_null = Q( estat__isnull = True )
                     
                     n_faltes = 0

--- a/aula/apps/tutoria/rpt_elsMeusAlumnesTutorats.py
+++ b/aula/apps/tutoria/rpt_elsMeusAlumnesTutorats.py
@@ -103,9 +103,9 @@ def elsMeusAlumnesTutoratsRpt( professor = None, grup = None  , dataDesDe = None
             f = controls.filter( alumne = alumne, estat__codi_estat = 'F' ).distinct().count() 
             r = controls.filter( alumne = alumne, estat__codi_estat = 'R' ).distinct().count() 
             if settings.CUSTOM_NO_CONTROL_ES_PRESENCIA:
-                p = controls.filter( alumne = alumne).filter( Q(estat__codi_estat = 'P') | Q(estat__codi_estat__isnull=True) ).distinct().count() 
+                p = controls.filter( alumne = alumne).filter( Q(estat__codi_estat__in = ['P','O']) | Q(estat__codi_estat__isnull=True) ).distinct().count()
             else:
-                p = controls.filter( alumne = alumne, estat__codi_estat = 'P' ).distinct().count() 
+                p = controls.filter( alumne = alumne, estat__codi_estat__in = ['P','O'] ).distinct().count()
             j = controls.filter( alumne = alumne, estat__codi_estat = 'J' ).distinct().count() 
             #ca = controls.filter(q_hores).filter(estat__codi_estat__isnull = False).filter( alumne = alumne ).distinct().count()
     

--- a/aula/apps/tutoria/rpt_elsMeusAlumnesTutorats.py
+++ b/aula/apps/tutoria/rpt_elsMeusAlumnesTutorats.py
@@ -110,8 +110,8 @@ def elsMeusAlumnesTutoratsRpt( professor = None, grup = None  , dataDesDe = None
             #ca = controls.filter(q_hores).filter(estat__codi_estat__isnull = False).filter( alumne = alumne ).distinct().count()
     
                 #-%--------------------------------------------
-            tpc_injust = (1.0*f) * 100.0 / (0.0+f+r+p+j)  if f > 0 else 0
-            tpc_assist = (0.0 + p + r ) * 100.0 / (0.0+f+r+p+j)  if f > 0 else 0
+            tpc_injust = (1.0*f) * 100.0 / (0.0+f+r+p+j)  if (f+r+p+j) > 0 else 0
+            tpc_assist = (0.0 + p + r ) * 100.0 / (0.0+f+r+p+j)  if (f+r+p+j) > 0 else 0
             
             camp = tools.classebuida()
             camp.enllac = None

--- a/aula/apps/tutoria/rpt_gestioCartes.py
+++ b/aula/apps/tutoria/rpt_gestioCartes.py
@@ -132,9 +132,9 @@ def gestioCartesRpt(professor, l4):
             f = controls.filter( alumne = alumne, estat__codi_estat = 'F' ).distinct().count()
             r = controls.filter( alumne = alumne, estat__codi_estat = 'R' ).distinct().count()
             if settings.CUSTOM_NO_CONTROL_ES_PRESENCIA:
-                p = controls.filter( alumne = alumne).filter( Q(estat__codi_estat = 'P') | Q(estat__codi_estat__isnull=True) ).distinct().count() 
+                p = controls.filter( alumne = alumne).filter( Q(estat__codi_estat__in = ['P', 'O']) | Q(estat__codi_estat__isnull=True) ).distinct().count()
             else:
-                p = controls.filter( alumne = alumne, estat__codi_estat = 'P' ).distinct().count() 
+                p = controls.filter( alumne = alumne, estat__codi_estat__in = ['P','O'] ).distinct().count()
             j = controls.filter( alumne = alumne, estat__codi_estat = 'J' ).distinct().count()
             #ca = controls.filter(q_hores).filter(estat__codi_estat__isnull = False).filter( alumne = alumne ).distinct().count()
     

--- a/aula/apps/tutoria/views.py
+++ b/aula/apps/tutoria/views.py
@@ -1759,7 +1759,7 @@ def detallTutoriaAlumne( request, pk , detall = 'all'):
         capcelera.contingut = u''
         taula.capceleres.append(capcelera)
         
-        for control in alumne.controlassistencia_set.exclude( estat__codi_estat = 'P' 
+        for control in alumne.controlassistencia_set.exclude( estat__codi_estat__in = ['P','O']
                                                               ).filter(  
                                                         estat__isnull=False                                                          
                                                             ).order_by( '-impartir__dia_impartir' , '-impartir__horari__hora'):


### PR DESCRIPTION
Degut a la situació actual molts alumnes estan confinats i seguint les classes de forma no presencial.
De vegades, tant professorat com conserges necessiten saber si aquests alumnes estan o han estat de forma presencial a classe o no.
Amb aquest Pull Request s'afegeix la possibilitat de marcar presència "Online"
Cal que l'administrador afegeixi un nou estat de control d'assistència a través del panel d'administració (https://path_djAu/admin):
![image](https://user-images.githubusercontent.com/4690871/106453519-bd0d6180-6489-11eb-911d-e7088af35971.png)

amb codi "O" i nom "Online"

![image](https://user-images.githubusercontent.com/4690871/106453825-2a20f700-648a-11eb-8629-2060924ce1de.png)

A partir d'aquest moment el professorat dispossarà d'aquesta opció en controlar presència

![image](https://user-images.githubusercontent.com/4690871/106454535-2e014900-648b-11eb-9484-ac3bde0e6802.png)

Aquest estat "Online" es tracta a tots els efectes com l'estat "Present"