### PR TITLE
Mostra més informació quan es cerca l'alumnat

### DIFF
--- a/aula/apps/alumnes/templates/mostraInfoAlumneCercat.html
+++ b/aula/apps/alumnes/templates/mostraInfoAlumneCercat.html
@@ -13,22 +13,29 @@
           <span class="glyphicon glyphicon-calendar"> </span> {{ dia }} <br />
           <span class="glyphicon glyphicon-briefcase"> </span> {{ alumne.grup }}, Tutor(a): {{alumne.tutorsDeLAlumne_display}}<br />
           {% if mostra_detalls %}
-          <span class="glyphicon glyphicon-home"> </span> {{ alumne.adreca }} ( {{ alumne.cp }}
-              {% if alumne.municipi == alumne.localitat %}
-                {{ alumne.localitat }}
-                {% else %}
-                    {% if alumne.municipi == '' %}
-                        {{ alumne.localitat }}
-                    {% elif alumne.localitat == '' %}
-                        {{ alumne.municipi }}
-                    {% else %}
-                        {{ alumne.localitat }}  -  {{ alumne.municipi }}
-                    {% endif %}
-                {% endif %}
-              )<br />
+              {% if es_tutor %}
+                      <span class="glyphicon glyphicon-home"> </span> {{ alumne.adreca }} ( {{ alumne.cp }}
+                          {% if alumne.municipi == alumne.localitat %}
+                            {{ alumne.localitat }}
+                            {% else %}
+                                {% if alumne.municipi == '' %}
+                                    {{ alumne.localitat }}
+                                {% elif alumne.localitat == '' %}
+                                    {{ alumne.municipi }}
+                                {% else %}
+                                    {{ alumne.localitat }}  -  {{ alumne.municipi }}
+                                {% endif %}
+                            {% endif %}
+                          )<br />
 
-          <span class="glyphicon glyphicon-user"> </span> {{ alumne.rp1_nom }} ({{ alumne.rp1_correu }} , {{ alumne.rp1_telefon }} - {{ alumne.rp1_mobil }})<br />
-          <span class="glyphicon glyphicon-user"> </span> {{ alumne.rp2_nom }} ({{ alumne.rp2_correu }} , {{ alumne.rp2_telefon }} - {{ alumne.rp2_mobil }})<br />
+                      <span class="glyphicon glyphicon-user"> </span> {{ alumne.rp1_nom }} ({{ alumne.rp1_correu }} , {{ alumne.rp1_telefon }} - {{ alumne.rp1_mobil }})<br />
+                      {% if alumne.rp2_nom %}
+                        <span class="glyphicon glyphicon-user"> </span> {{ alumne.rp2_nom }} ({{ alumne.rp2_correu }} , {{ alumne.rp2_telefon }} - {{ alumne.rp2_mobil }})<br />
+                      {% endif %}
+              {% endif %}
+              {% if alumne.observacions %}
+                <span class="glyphicon glyphicon-info-sign"> </span> {{alumne.observacions}}
+              {% endif %}
           {% endif %}
       	</p>
           </div>


### PR DESCRIPTION
Fins ara:
- Quan es cerca un alumne/a es mostra informació bàsica (nom, data i tutor). 
- Si la cerca la realitza un usuari del grup de [direcció, sortides o consergeria] es mostra informació més detallada.
Aquest PR afegeix que:
- El professorat de l'alumne/a cercat podrà veure també el camp d'observacions.
- El/s tutor/a/s/es de l'alumne/a cercat podrà veure la informació detallada