### PR TITLE
appy correcte per python >=3.6

### DIFF
--- a/aula/apps/avaluacioQualitativa/reports.py
+++ b/aula/apps/avaluacioQualitativa/reports.py
@@ -70,7 +70,7 @@ def reportQualitativa( qualitativa , alumnes = [], grups = [], request = None):
                        
     #from django.template import Context                              
     from appy.pod.renderer import Renderer
-    import cgi
+    import html
     import os
     from django import http
     import time
@@ -101,7 +101,7 @@ def reportQualitativa( qualitativa , alumnes = [], grups = [], request = None):
         response = http.HttpResponse( contingut, content_type='application/vnd.oasis.opendocument.text')
         response['Content-Disposition'] = 'attachment; filename=qualitativa.odt'
     else:
-        response = http.HttpResponse('''Gremlin's ate your pdf! %s''' % cgi.escape(excepcio))
+        response = http.HttpResponse('''Gremlin's ate your pdf! %s''' % html.escape(excepcio))
 
     
     return response

--- a/aula/apps/baixes/rpt_carpeta.py
+++ b/aula/apps/baixes/rpt_carpeta.py
@@ -55,7 +55,7 @@ def reportBaixaCarpeta( request, dia, professors ):
                     
                        
     #from django.template import Context                              
-    import cgi
+    import html
     import os
     from django import http
     import time
@@ -86,7 +86,7 @@ def reportBaixaCarpeta( request, dia, professors ):
         response = http.HttpResponse( contingut, content_type='application/vnd.oasis.opendocument.text')
         response['Content-Disposition'] = 'attachment; filename=professor-baixa.odt'
     else:
-        response = http.HttpResponse('''Gremlin's ate your pdf! %s''' % cgi.escape(excepcio))
+        response = http.HttpResponse('''Gremlin's ate your pdf! %s''' % html.escape(excepcio))
 
     
     return response

--- a/aula/apps/extSaga/sincronitzaSaga.py
+++ b/aula/apps/extSaga/sincronitzaSaga.py
@@ -18,7 +18,6 @@ import csv, time
 from aula.apps.extSaga.models import Grup2Aula
 
 from django.conf import settings
-from appy.pod.buffers import ELSE_WITHOUT_IF
 
 from aula.utils.tools import unicode
 

--- a/aula/apps/incidencies/views.py
+++ b/aula/apps/incidencies/views.py
@@ -1437,7 +1437,7 @@ def cartaSancio( request, pk ):
     
     #from django.template import Context                              
     from appy.pod.renderer import Renderer
-    import cgi
+    import html
     import os
     from django import http
     import time
@@ -1470,7 +1470,7 @@ def cartaSancio( request, pk ):
         response['Content-Disposition'] = u'attachment; filename="{0}-{1}.odt"'.format( nom_fitxer, slugify( unicode(sancio.alumne ) ) )
                                                      
     else:
-        response = http.HttpResponse('''Als Gremlin no els ha agradat aquest fitxer! %s''' % cgi.escape(excepcio))
+        response = http.HttpResponse('''Als Gremlin no els ha agradat aquest fitxer! %s''' % html.escape(excepcio))
     
     return response
 

--- a/aula/apps/sortides/views.py
+++ b/aula/apps/sortides/views.py
@@ -127,7 +127,7 @@ def imprimir( request, pk, din = '4'):
 
     #from django.template import Context                              
     from appy.pod.renderer import Renderer
-    import cgi
+    import html
     import os
     from django import http
     
@@ -160,7 +160,7 @@ def imprimir( request, pk, din = '4'):
         response['Content-Disposition'] = u'attachment; filename="{0}-{1}.odt"'.format( "autoritzacio_sortida", pk )
                                                      
     else:
-        response = http.HttpResponse('''Als Gremlin no els ha agradat aquest fitxer! %s''' % cgi.escape(excepcio))
+        response = http.HttpResponse('''Als Gremlin no els ha agradat aquest fitxer! %s''' % html.escape(excepcio))
     
     return response
     
@@ -1051,7 +1051,7 @@ def sortidaExcel( request, pk ):
     })
 
     import os
-    import cgi
+    import html
     import time
     from django import http
     import xlsxwriter
@@ -1091,7 +1091,7 @@ def sortidaExcel( request, pk ):
         response['Content-Disposition'] = u'attachment; filename="sortida-{0}.xlsx"'.format( slugify( sortida.titol_de_la_sortida ))
 
     else:
-        response = http.HttpResponse('''Als Gremlin no els ha agradat aquest fitxer! %s''' % cgi.escape(excepcio))
+        response = http.HttpResponse('''Als Gremlin no els ha agradat aquest fitxer! %s''' % html.escape(excepcio))
 
     return response
 

--- a/aula/apps/tutoria/report_carta_absentisme.py
+++ b/aula/apps/tutoria/report_carta_absentisme.py
@@ -13,7 +13,7 @@ def report_cartaAbsentisme( request, carta ):
                        
     #from django.template import Context                              
     from appy.pod.renderer import Renderer
-    import cgi
+    import html
     import os
     from django import http
     import time
@@ -84,7 +84,7 @@ def report_cartaAbsentisme( request, carta ):
         response = http.HttpResponse( contingut, content_type='application/vnd.oasis.opendocument.text')
         response['Content-Disposition'] = 'attachment; filename=cartaAbsencies.odt'
     else:
-        response = http.HttpResponse('''Gremlin's ate you! %s''' % cgi.escape(excepcio))
+        response = http.HttpResponse('''Gremlin's ate you! %s''' % html.escape(excepcio))
 
     
     return response

--- a/aula/apps/tutoria/reports.py
+++ b/aula/apps/tutoria/reports.py
@@ -197,7 +197,7 @@ def reportFaltesIncidencies( dataInici, dataFi , alumnes_informe = [], alumnes_r
                        
     #from django.template import Context                              
     from appy.pod.renderer import Renderer
-    import cgi
+    import html
     import os
     from django import http
     import time
@@ -228,7 +228,7 @@ def reportFaltesIncidencies( dataInici, dataFi , alumnes_informe = [], alumnes_r
         response = http.HttpResponse( contingut, content_type='application/vnd.oasis.opendocument.text')
         response['Content-Disposition'] = 'attachment; filename=assistencia_i_incidencies.odt'
     else:
-        response = http.HttpResponse('''Els Gremlins odien el teu llistat! %s''' % cgi.escape(excepcio))
+        response = http.HttpResponse('''Els Gremlins odien el teu llistat! %s''' % html.escape(excepcio))
 
     
     return response                       

--- a/aula/templates/base.html
+++ b/aula/templates/base.html
@@ -11,7 +11,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <link rel="stylesheet" href="{{STATIC_URL}}bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="{{STATIC_URL}}glyphicons/css/bootstrap-glyphicons.css">
+<link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+<!-- <link rel="stylesheet" href="{{STATIC_URL}}glyphicons/css/bootstrap-glyphicons.css"> -->
 <title>django-aula | {% block title %}{% endblock %}</title>
 
 <script src="{{STATIC_URL}}jquery/jquery-2.1.4.min.js"></script>

--- a/aula/utils/tools.py
+++ b/aula/utils/tools.py
@@ -7,7 +7,7 @@ from django.template import Context
 from django.conf import settings
 
 from io import StringIO
-import cgi
+import html
 from django.core.validators import validate_ipv4_address
 from django.core.exceptions import ValidationError
 from django.contrib.auth import logout
@@ -161,7 +161,7 @@ def write_pdf(template_src, context_dict):
         response = http.HttpResponse( result.getvalue(), mimetype='application/pdf')
         response['Content-Disposition'] = 'attachment; filename=qualitativa.pdf'
     else:
-        response = http.HttpResponse('''Gremlin's ate your pdf! %s''' % cgi.escape(html))
+        response = http.HttpResponse('''Gremlin's ate your pdf! %s''' % html.escape(html))
 
     
     return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,13 @@
 wheel
 openpyxl
-# Development
-git+https://github.com/lino-framework/appypod.git#egg=appy
+git+https://github.com/lino-framework/appypod.git#egg=appy ; python_version < '3.6'
+appy ; python_version >= '3.6'
 Django
 django-extensions
 django-environ
 lxml
-django-appypod
 six
 django-debug-toolbar
-# python-lxml
 python-dateutil
 django-tables2
 icalendar


### PR DESCRIPTION
Adaptació a la versió correcte d'appy.
Es fa servir [https://appyframe.work/tool/public](https://appyframe.work/tool/public). Segons indica a la documentació, és vàlida per python 3.6 o superior.
Django-appypod no fa falta, no es fa servir. L'última versió de Django-appypod també fa servir el mateix paquet appy. 

Substitució de cgi.escape per html.escape, cgi no és vàlid des de python 3.9.

També s'ha corregit la referència a bootstrap-glyphicons.css

closes: #171 closes: #142