### PR TITLE
Fixar comanda find per MacOs

### DIFF
--- a/scripts/fixtures.sh
+++ b/scripts/fixtures.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 cd `dirname $0`/..
-FILES=`find -name 'dades.json'`
+FILES=`find ./aula -name 'dades.json'`
 for i in $FILES
 do
         python manage.py loaddata $i


### PR DESCRIPTION
Al meu pc falla el `scripts/fixtures.sh` perquè es veu que el macos demana el path abans dels paràmetres a la comanda `find`.