### PR TITLE
[BugFix] Es matxaca el nom sentit en sincronitzar

### DIFF
--- a/aula/apps/alumnes/tables2_models.py
+++ b/aula/apps/alumnes/tables2_models.py
@@ -38,3 +38,33 @@ class HorariAlumneTable(tables.Table):
         attrs = {"class": "paleblue table table-striped"}
         template = 'bootable2.html'
 
+class AlumneNomSentitTable(tables.Table):
+
+    nom_sentit = tables.TemplateColumn(
+                        verbose_name='Nom Sentit',
+                        template_code=u"""
+                        {{ record.nom_sentit }}
+                        """,
+                        order_by='nom_sentit',
+                        )
+
+    nom_i_cognoms = tables.TemplateColumn(
+                        verbose_name='Alumne',
+                        template_code=u"""
+                        {{ record.cognom_nom }}
+                        """,
+                        order_by='cognom_nom',
+                        )
+
+    actioin = tables.TemplateColumn(
+                        verbose_name='',
+                        template_code=u"""
+                        <a href="{% url 'psico__nomsentit__w2' record.id %}" class="btn btn-primary btn-xs">Canviar</a>
+                        
+                        """,
+                        orderable=False,
+                        )
+    class Meta:
+        # add class="paleblue" to <table> tag
+        attrs = {"class": "paleblue table table-striped"}
+        template = 'bootable2.html'

--- a/aula/apps/alumnes/urls.py
+++ b/aula/apps/alumnes/urls.py
@@ -28,6 +28,9 @@ urlpatterns = [
    re_path(r'^informePsicopedagoc/$', alumnes_views.informePsicopedagoc,
        name="psico__informes_alumne__list"),
                        
+   re_path(r'^nomsentitw0/$', alumnes_views.canviarNomSentitW0,
+       name="psico__nomsentit__w0"),
+                       
    re_path(r'^nomsentitw1/$', alumnes_views.canviarNomSentitW1,
        name="psico__nomsentit__w1"),
                        

--- a/aula/apps/alumnes/views.py
+++ b/aula/apps/alumnes/views.py
@@ -7,7 +7,7 @@ from django.template import RequestContext, loader
 #tables
 from django.utils.safestring import mark_safe
 
-from aula.apps.alumnes.tables2_models import HorariAlumneTable
+from aula.apps.alumnes.tables2_models import AlumneNomSentitTable, HorariAlumneTable
 from django_tables2 import RequestConfig
 
 #from django import forms as forms
@@ -214,6 +214,37 @@ def informePsicopedagoc( request  ):
                      'head': 'Triar alumne'
                     }
                 )
+
+
+@login_required
+@group_required(['direcció','psicopedagog'])
+def canviarNomSentitW0( request  ):
+
+    alumnes = list(
+        Alumne
+        .objects
+        .exclude(nom_sentit="")
+        .values('id', 'cognoms', 'nom', 'nom_sentit')
+        .order_by('nom_sentit')
+    )
+    for a in alumnes:
+        a['cognom_nom'] = a['cognoms'] + ", " + a['nom']
+
+    table=AlumneNomSentitTable(alumnes)
+    table.order_by = 'nom_sentit'
+
+    RequestConfig(request).configure(table)
+
+    return render(
+        request,
+        'table2.html',
+        {
+            'table': table,
+            'urladd': reverse( 'psico__nomsentit__w1' ),
+            'txtadd': "Nou alumne amb nom sentit",
+            'titol_formulari': u"Alumnes amb Nom Sentit",
+         },
+    )    
 
 
 @login_required

--- a/aula/apps/extEsfera/sincronitzaEsfera.py
+++ b/aula/apps/extEsfera/sincronitzaEsfera.py
@@ -186,6 +186,7 @@ def sincronitza(f, user = None):
         else:
             #TODO: si canvien dades importants avisar al tutor.
             a.pk = alumneDadesAnteriors.pk
+            a.nom_sentit = alumneDadesAnteriors.nom_sentit
             a.estat_sincronitzacio = 'S-U'
             info_nAlumnesModificats+=1
 

--- a/aula/apps/extSaga/sincronitzaSaga.py
+++ b/aula/apps/extSaga/sincronitzaSaga.py
@@ -205,6 +205,7 @@ def sincronitza(f, user = None):
             #TODO: si canvien dades importants avisar al tutor.
             a.pk = alumneDadesAnteriors.pk
             a.estat_sincronitzacio = 'S-U'
+            a.nom_sentit = alumneDadesAnteriors.nom_sentit
             info_nAlumnesModificats+=1
 
             # En cas que l'alumne pertanyi a un dels grups parametritzat com a estàtic,

--- a/aula/templates/table2.html
+++ b/aula/templates/table2.html
@@ -14,6 +14,12 @@
 
 	{% render_table table %}
 
+	{% if urladd %}
+	<a class="btn btn-primary" href="{{urladd}}">
+		{{ txtadd |default:"Afegir element" }}
+	</a>
+	{% endif %}
+
 	{% block posttaula %} {% endblock %}
 
-{% endblock %}
+{% endblock %} 

--- a/aula/utils/menu.py
+++ b/aula/utils/menu.py
@@ -203,7 +203,7 @@ def calcula_menu( user , path, sessioImpersonada ):
                   (
                       ("Informe d'Alumne", 'psico__informes_alumne__list', pg or di, None, None ),
                       ("Actuacions", 'psico__actuacions__list', pg or di, None, None ),
-                      ("Alumne, canvi nom sentit", 'psico__nomsentit__w1', pg or di, None, None ),
+                      ("Alumne, nom sentit", 'psico__nomsentit__w0', pg or di, None, None ),
                    )
                ),
 


### PR DESCRIPTION
### Motivació

* Fix #203 

### En aquesta PR

* b3bb85d47f7ca12534728c7318b33a638e5b6a1b El nom sentit es perdia en sincronitzar. Fixat en aquest commit.
* c8d6c5d0e1f72140eb3cb29dde376ff16058d233 Afegit un botó (per defecte no surt) a `tables2.html` per afegir nous elements a la taula.
* 6c214bd573a78cf4b7abb66337041ee80eccd586 Modificada la UI. Ara apareix una llista dels alumnes que tenen informat el `nom sentit` per tal que sigui més fàcil la seva gesió.

### ScreenShot

<img width="1220" alt="captura de pantalla nom sentit" src="https://user-images.githubusercontent.com/3105983/192597322-56814273-19ff-415c-a385-9db630b7249f.png">


### Nota

Please, en aquest cas, merge normal, **sense** "Squash & Merge"

