### PR TITLE
Permet escollir límit de logins erronis

### DIFF
--- a/aula/apps/usuaris/views.py
+++ b/aula/apps/usuaris/views.py
@@ -349,13 +349,16 @@ def loginUser( request ):
                     if user.is_active:
                         #comprova els intents fallits des del darrer intent bó.
                         #Utilitza el paràmetre 'limitLogin' de ParametreKronowin
+                        #El valor per defecte és l'indicat a LIMITLOGIN dels settings
+                        defecte=settings.LIMITLOGIN
                         try:
                             limitLoginFail, _ = ParametreKronowin.objects.get_or_create(nom_parametre='limitLogin',
-                                                            defaults={'valor_parametre': '3', })
+                                                            defaults={'valor_parametre': str(defecte), })
                             limitLoginFail=int(limitLoginFail.valor_parametre)
                         except:
-                            limitLoginFail=3
-                        if limitLoginFail<3: limitLoginFail=3
+                            limitLoginFail=defecte
+                        #No es permet un valor inferior al de defecte
+                        if limitLoginFail<defecte: limitLoginFail=defecte
                         #fa_5_minuts = datetime.now() - timedelta(minutes = 5)
                         logins_anteriors = LoginUsuari.objects.filter( 
                                                 usuari = user 

--- a/aula/apps/usuaris/views.py
+++ b/aula/apps/usuaris/views.py
@@ -348,17 +348,8 @@ def loginUser( request ):
                     LoginUsuari.objects.create( usuari = user, exitos = False, ip = client_address)                    
                     if user.is_active:
                         #comprova els intents fallits des del darrer intent bó.
-                        #Utilitza el paràmetre 'limitLogin' de ParametreKronowin
-                        #El valor per defecte és l'indicat a LIMITLOGIN dels settings
-                        defecte=settings.LIMITLOGIN
-                        try:
-                            limitLoginFail, _ = ParametreKronowin.objects.get_or_create(nom_parametre='limitLogin',
-                                                            defaults={'valor_parametre': str(defecte), })
-                            limitLoginFail=int(limitLoginFail.valor_parametre)
-                        except:
-                            limitLoginFail=defecte
-                        #No es permet un valor inferior al de defecte
-                        if limitLoginFail<defecte: limitLoginFail=defecte
+                        #El valor és l'indicat a LIMITLOGIN dels settings
+                        limitLoginFail=settings.LIMITLOGIN
                         #fa_5_minuts = datetime.now() - timedelta(minutes = 5)
                         logins_anteriors = LoginUsuari.objects.filter( 
                                                 usuari = user 

--- a/aula/settings_dir/common.py
+++ b/aula/settings_dir/common.py
@@ -266,3 +266,7 @@ LOGGING = {
 
 
 PRIVATE_STORAGE_AUTH_FUNCTION = 'aula.utils.views.allow_private_files'
+
+#Quantitat, per defecte, de logins errònis abans de bloquejar usuari
+#Aquest valor és el mínim, es pot augmentar amb el paràmetre 'limitLogin' de ParametreKronowin
+LIMITLOGIN = 3

--- a/aula/settings_dir/common.py
+++ b/aula/settings_dir/common.py
@@ -268,5 +268,4 @@ LOGGING = {
 PRIVATE_STORAGE_AUTH_FUNCTION = 'aula.utils.views.allow_private_files'
 
 #Quantitat, per defecte, de logins errònis abans de bloquejar usuari
-#Aquest valor és el mínim, es pot augmentar amb el paràmetre 'limitLogin' de ParametreKronowin
 LIMITLOGIN = 3

--- a/aula/utils/menu.py
+++ b/aula/utils/menu.py
@@ -16,10 +16,6 @@ def calcula_menu( user , path, sessioImpersonada ):
 
     if not user.is_authenticated:
         return
-    
-    # No permet impersonació com a administrador
-    if sessioImpersonada and Group.objects.get_or_create(name= 'administradors' )[0] in user.groups.all():
-        return
 
     #mire a quins grups està aquest usuari:
     al = Group.objects.get_or_create(name= 'alumne' )[0] in user.groups.all()


### PR DESCRIPTION
A vegades els usuaris fallen en posar la contrasenya, per oblit, per fer servir un equip diferent de l'habitual que ja té guardada una contrasenya antiga, per confusió en l'username. Actualment el límit és de 3 intents, si se supera el límit, es bloqueja l'usuari.
Per a poder augmentar la quantitat límit, s'ha afegit un paràmetre als settings LIMITLOGIN=3.

Més canvis:
S'ha modificat la manera d'impedir que un usuari de direcció pugui fer impersonació com a administrador. Ara mostra un missatge informatiu.