### PR TITLE
Reserva d'aules

### DIFF
--- a/aula/apps/aules/forms.py
+++ b/aula/apps/aules/forms.py
@@ -59,9 +59,9 @@ class disponibilitatAulaPerFranjaForm(forms.Form):
                            .filter(horari__impartir__dia_impartir=data)
                            .order_by('hora_inici')
                            )
-        primera_franja = franges_del_dia.first()
-        darrera_franja = franges_del_dia.last()
-        if not primera_franja or franja.hora_inici < primera_franja.hora_inici or franja.hora_fi > darrera_franja.hora_fi:
+
+        #Es comprova que la franja correspongui al dia
+        if not franges_del_dia or not franja in franges_del_dia:
             raise forms.ValidationError(u"En aquesta franja i dia no hi ha docència")
 
         return cleaned_data
@@ -100,6 +100,14 @@ class reservaAulaForm(ModelForm):
                    required=True,
                    help_text="Aula a reservar")
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        #No es permet fer canvis a aula, dia ni hora
+        #Les dades ja s'han verificat anteriorment
+        self.fields['aula'].disabled=True
+        self.fields['dia_reserva'].disabled=True
+        self.fields['hora'].disabled=True
+        
     def clean_hora(self):
 
         franja = self.cleaned_data['hora']

--- a/aula/apps/material/forms.py
+++ b/aula/apps/material/forms.py
@@ -62,9 +62,8 @@ class disponibilitatRecursPerFranjaForm(forms.Form):
                            .filter(horari__impartir__dia_impartir=data)
                            .order_by('hora_inici')
                            )
-        primera_franja = franges_del_dia.first()
-        darrera_franja = franges_del_dia.last()
-        if not franja or not primera_franja or not darrera_franja or (franja.hora_inici < primera_franja.hora_inici or franja.hora_fi > darrera_franja.hora_fi):
+        #Es comprova que la franja correspongui al dia
+        if not franges_del_dia or not franja in franges_del_dia:
             raise forms.ValidationError(u"En aquesta franja i dia no hi ha docència")
 
         return cleaned_data
@@ -94,6 +93,14 @@ class reservaRecursForm(ModelForm):
                    required=True,
                    help_text="Material a reservar")
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        #No es permet fer canvis a recurs, dia ni hora
+        #Les dades ja s'han verificat anteriorment
+        self.fields['recurs'].disabled = True
+        self.fields['dia_reserva'].disabled = True
+        self.fields['hora'].disabled = True
+        
     def clean_hora(self):
 
         franja = self.cleaned_data['hora']


### PR DESCRIPTION
Si les franges se superposen, no es detecta adequadament si és lliure.
Per exemple:
ESO fa horari de 10:20-11:20 i 11:20:12:20
BAT fa horari de 10:00-11:00 i 11:30-12:30
El Djau pot tenir una aula reservada de 10:20-11:20, però la considera lliure de 10:00-11:00.
Al final del procés, al formulari final, permet fer canvis de les dades seleccionades anteriorment. Prèviament, ja s'ha seleccionat dia, hora i aula correctes.
Aquest pull request corregeix la selecció de franges i bloqueja les dades al formulari final.
El canvi s'ha fet per a reserva d'aules i també per a reserva de material.