### PR TITLE
requirements.txt i django-private-storage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ wheel
 openpyxl
 git+https://github.com/lino-framework/appypod.git#egg=appy ; python_version < '3.6'
 appy ; python_version >= '3.6'
-Django < 4 ; python_version < '3.8.10'
-Django >= 4 ; python_version >= '3.8.10'
+Django < 4 ; python_version < '3.8'
+Django == 4.1.8 ; python_version >= '3.8'
 django-extensions
 django-environ
 lxml


### PR DESCRIPTION
django-private-storage provoca error amb Django 4.2
from django.core.files.storage import File, Storage ImportError: cannot import name 'File' from 'django.core.files.storage'
De moment només es permet Django 4.1.8
