### PR TITLE
Canvi a Django 4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ openpyxl
 git+https://github.com/lino-framework/appypod.git#egg=appy ; python_version < '3.6'
 appy ; python_version >= '3.6'
 Django < 4 ; python_version < '3.8'
-Django == 4.1.8 ; python_version >= '3.8'
+Django == 4.2 ; python_version >= '3.8'
 django-extensions
 django-environ
 lxml


### PR DESCRIPTION
django-private-storage ha sigut actualitzat, la versió 3.1 funciona amb Django 4.2. Close #226
De moment no es fa servir la 4.2.1, ja que s'han fet uns canvis als widgets ClearableFileInput i FileInput.
S'ha de revisar l'ús d'aquests widgets.