### PR TITLE
Verificacions addicionals i millores a preinscripció i matrícula

### DIFF
--- a/aula/apps/extPreinscripcio/forms.py
+++ b/aula/apps/extPreinscripcio/forms.py
@@ -1,4 +1,18 @@
 from django import forms as forms
+from aula.apps.extPreinscripcio.sincronitza import testMatActiva
 
 class PreinscripcioForm(forms.Form):
     fitxer_Preinscripcio = forms.FileField(required=True, label="Fitxer de la preinscripció")
+    resetPrevious=forms.BooleanField(label=u"Elimina dades anteriors",required = False,
+                                help_text=u"S'esborren preinscripcions pendents, d'activació de matrícula, dels mateixos \
+                                estudis. No s'ha de fer servir si volem carregar preinscripcions des de diversos fitxers.")
+
+    def clean(self):
+        cleaned_data = super().clean()
+        f=cleaned_data.get('fitxer_Preinscripcio')
+        matActiva, missatge = testMatActiva(f)
+        if matActiva or missatge:
+            # Hi ha alguna preinscripció amb matrícula activa per als mateixos estudis
+            # o s'ha produit un error d'accés al fitxer.
+            self.add_error('fitxer_Preinscripcio', missatge)
+        return cleaned_data

--- a/aula/apps/extPreinscripcio/views.py
+++ b/aula/apps/extPreinscripcio/views.py
@@ -22,9 +22,9 @@ def importaFitxer(request):
     if request.method == 'POST':
         form = PreinscripcioForm(request.POST, request.FILES)
         if form.is_valid():
-
-            f = request.FILES['fitxer_Preinscripcio']
-            resultat = s.sincronitza(f, user)
+            f = form.cleaned_data.get('fitxer_Preinscripcio')
+            resetPrevious = form.cleaned_data.get('resetPrevious')
+            resultat = s.sincronitza(f, resetPrevious, user)
             if Nivell2Aula.objects.filter(nivellDjau__isnull=True):
                 return HttpResponseRedirect(reverse_lazy('administracio__configuracio__preinscripcio'))
             return render(
@@ -37,7 +37,7 @@ def importaFitxer(request):
         form = PreinscripcioForm()
     return render(
                         request,
-                        'importa.html', 
+                        'form.html', 
                         {'form': form},
                  )
 

--- a/aula/apps/matricula/forms.py
+++ b/aula/apps/matricula/forms.py
@@ -317,9 +317,6 @@ class ActivaMatsForm(forms.Form):
                                 Opció adequada si la casuística és diversa, canvis de centre, abandonaments o ja s'ha obtingut el títol.")
     exclusiu=forms.BooleanField(label=u"Exclusivament preinscripcions",required = False,
                                 help_text=u"Només es permet matrícula amb preinscripció. Els alumnes que continuen al centre no podran accedir.")
-    forceActivation=forms.BooleanField(label=u"Força activació",required = False,
-                                help_text=u"Força l'activació només amb les preinscripcions importades des de l'última activació. \
-                                S'esborren altres preinscripcions anteriors per als mateixos estudis.")
     
     def __init__(self, user, *args, **kwargs):
         super(ActivaMatsForm, self).__init__(*args, **kwargs)
@@ -334,11 +331,11 @@ class ActivaMatsForm(forms.Form):
             self.add_error('datalimit', "Data és anterior a l'actual.")
         nivell=cleaned_data.get('nivell')
         tipus=cleaned_data.get('tipus')
-        forceActivation=cleaned_data.get('forceActivation')
         nany=django.utils.timezone.now().year
-        if tipus=='P' and not forceActivation \
+        if tipus=='P' \
             and nivell.matricula_oberta and nivell.limit_matricula>=django.utils.timezone.now().date() \
             and Preinscripcio.objects.filter(estat='Enviada', codiestudis=nivell.nom_nivell, any=nany) \
             and Preinscripcio.objects.filter(estat='Assignada', codiestudis=nivell.nom_nivell, any=nany, naixement__isnull=False):
-                self.add_error('forceActivation', "Hi ha preinscripcions vàlides d'una activació anterior. Marca 'Força activació' per esborrar-les.")
+                self.add_error('nivell', "Hi ha preinscripcions vàlides d'una activació anterior. \
+                           Per a poder continuar primer ha de finalitzar la matrícula activa actual a "+nivell.nom_nivell)
         return cleaned_data

--- a/aula/apps/matricula/forms.py
+++ b/aula/apps/matricula/forms.py
@@ -310,13 +310,16 @@ class ActivaMatsForm(forms.Form):
                                          ('C','Confirmacions'),
                                          ('A','Altres'),
                                          ])
-    ultimCursNoEmail=forms.BooleanField(label=u'No envia emails a alumnes d\'últim curs',required = False,
-                                help_text=u'Sense emails a alumnes d\'últim curs, segurament ja tenen el títol.')
-    senseEmails=forms.BooleanField(label=u'No envia emails',required = False,
-                                help_text=u'Si ja s\'ha donat la informació directament als alumnes. \
-                                Opció adequada si no es pot concretar qui continua, canvia de centre o obté el títol.')
-    exclusiu=forms.BooleanField(label=u'Exclusivament preinscripcions',required = False,
-                                help_text=u'Només es permet matrícula amb preinscripció. Els alumnes que continuen al centre no podran accedir.')
+    ultimCursNoEmail=forms.BooleanField(label=u"No envia emails a alumnes d'últim curs",required = False,
+                                help_text=u"Sense emails a alumnes d'últim curs, segurament ja tenen el títol.")
+    senseEmails=forms.BooleanField(label=u"No envia emails",required = False,
+                                help_text=u"Si ja s'ha donat la informació directament als alumnes. \
+                                Opció adequada si la casuística és diversa, canvis de centre, abandonaments o ja s'ha obtingut el títol.")
+    exclusiu=forms.BooleanField(label=u"Exclusivament preinscripcions",required = False,
+                                help_text=u"Només es permet matrícula amb preinscripció. Els alumnes que continuen al centre no podran accedir.")
+    forceActivation=forms.BooleanField(label=u"Força activació",required = False,
+                                help_text=u"Força l'activació només amb les preinscripcions importades des de l'última activació. \
+                                S'esborren altres preinscripcions anteriors per als mateixos estudis.")
     
     def __init__(self, user, *args, **kwargs):
         super(ActivaMatsForm, self).__init__(*args, **kwargs)
@@ -328,5 +331,14 @@ class ActivaMatsForm(forms.Form):
         cleaned_data = super(ActivaMatsForm, self).clean()
         datalimit = cleaned_data.get('datalimit')
         if django.utils.timezone.now().date()>datalimit:
-            self.add_error('datalimit', "Data és anterior a l'actual")
+            self.add_error('datalimit', "Data és anterior a l'actual.")
+        nivell=cleaned_data.get('nivell')
+        tipus=cleaned_data.get('tipus')
+        forceActivation=cleaned_data.get('forceActivation')
+        nany=django.utils.timezone.now().year
+        if tipus=='P' and not forceActivation \
+            and nivell.matricula_oberta and nivell.limit_matricula>=django.utils.timezone.now().date() \
+            and Preinscripcio.objects.filter(estat='Enviada', codiestudis=nivell.nom_nivell, any=nany) \
+            and Preinscripcio.objects.filter(estat='Assignada', codiestudis=nivell.nom_nivell, any=nany, naixement__isnull=False):
+                self.add_error('forceActivation', "Hi ha preinscripcions vàlides d'una activació anterior. Marca 'Força activació' per esborrar-les.")
         return cleaned_data

--- a/aula/apps/matricula/views.py
+++ b/aula/apps/matricula/views.py
@@ -538,8 +538,8 @@ def ActivaMatricula(request):
                                 'resultat.html', 
                                 {'msgs': {'errors': [], 'warnings': [], 'infos': infos} },
                                  )
-                # Marca Preinscripcions 'Enviada' del mateix nivell com a 'Caducada'
-                # Així s'evita que preinscripcions anteriors puguin continuar la matrícula
+                # Marca Preinscripcions d'estat 'Enviada', del mateix nivell, com a 'Caducada'
+                # Així s'evita que preinscripcions, de matrícules activades anteriorment, puguin continuar la matrícula
                 Preinscripcio.objects.filter(estat='Enviada', codiestudis=nivell.nom_nivell, any=nany).update(estat='Caducada')
                 nivell.limit_matricula=datalimit
                 nivell.matricula_oberta=True
@@ -559,7 +559,8 @@ def ActivaMatricula(request):
                 nivell.save()
                 
             enviaIniciMat(nivell, tipus, nany, ultimCursNoEmail, senseEmails)
-            infomat='Matrícula activada de tipus {0} per {1} amb data límit {2}'.format(tipus, nivell.nom_nivell, 
+            definicions={'P': 'preinscripció', 'A': 'altres', 'C': 'confirmació'}
+            infomat='Matrícula activada de tipus {0} per {1} amb data límit {2}'.format(definicions.get(tipus,''), nivell.nom_nivell, 
                                                             datalimit.strftime('%d/%m/%Y'))
             if senseEmails:
                 infos.append(infomat+'.')

--- a/aula/apps/missatgeria/missatges_a_usuaris.py
+++ b/aula/apps/missatgeria/missatges_a_usuaris.py
@@ -85,6 +85,8 @@ IMPORTACIO_ESFERA_FINALITZADA = u"Importació Esfer@ finalitzada."
 
 IMPORTACIO_PREINSCRIPCIO_FINALITZADA = u"Importació de la preinscripció finalitzada."
 
+ACTIVACIO_MATRICULA_FINALITZADA = "Activació de matrícula completada."
+
 IMPORTACIO_DADES_ADDICIONALS_FINALITZADA = u"Importació dades addicionals finalitzada."
 
 ERROR_SIGNATURES_REPORT_PAGAMENT_ONLINE = u"Redsys: No hi ha coincidència entre firma rebuda {0}, i calculada {1}, en dades corresponents a report de transacció online"
@@ -133,6 +135,7 @@ MISSATGES = {'ADMINISTRACIO' : {'warning': {PASSAR_LLISTA_GRUP_NO_MEU,
                                 FI_INITDB,
                                 ERROR_INITDB,
                                 IMPORTACIO_PREINSCRIPCIO_FINALITZADA,
+                                ACTIVACIO_MATRICULA_FINALITZADA,
                                 }},
              'DISCIPLINA': {'danger': {EXPULSIO_PER_ACUMULACIO_INCIDENCIES,
                                        EXPULSIO_PER_ACUMULACIO_INCIDENCIES_FORA_AULA,


### PR DESCRIPTION
Comprovacions addicionals per no sobreescriure dades de preinscripció ni d'activació de matrícula.
Afegeix més informació als missatges d'importació de preinscripcions i d'activació de matrícula.
Per defecte permet afegir les dades en diversos fitxers separats, opcionalment es poden esborrar les dades antigues i tornar a començar.