### PR TITLE
Control ip's pagament online

### DIFF
--- a/aula/apps/missatgeria/missatges_a_usuaris.py
+++ b/aula/apps/missatgeria/missatges_a_usuaris.py
@@ -91,7 +91,7 @@ ERROR_SIGNATURES_REPORT_PAGAMENT_ONLINE = u"Redsys: No hi ha coincidència entre
 
 ERROR_FALTEN_DADES_REPORT_PAGAMENT_ONLINE = u"Redsys: Falta nombre d'ordre ({0}) o codi autorització ({1}) o firma ({2}) en report de transacció online"
 
-ERROR_IP_NO_PERMESA_REPORT_PAGAMENT_ONLINE =u"Redsys: Intent de reportar transacció online desde IP no permesa {0}"
+ERROR_IP_NO_PERMESA_REPORT_PAGAMENT_ONLINE =u"Redsys: Intent de reportar transacció online desde IP no permesa {0} , {1}"
 
 MAIL_REBUTJAT=u"Mail rebutjat per l'usuari: \"{0}\"  adreça: \"{1}\".\nData d'enviament: {2}\nMotiu: {3}"
 

--- a/aula/apps/sortides/views.py
+++ b/aula/apps/sortides/views.py
@@ -1430,10 +1430,11 @@ def retornTransaccio(request,pk):
                     '195.76.9.222',
                     '194.224.159.47',
                     '194.224.159.57']  # ip's Banc Sabadell
-    ip = request.META.get('REMOTE_ADDR')
-    if ip not in ips_permeses:
+    ip1 = request.META.get('REMOTE_ADDR')
+    ip2 = request.META.get('HTTP_X_FORWARDED_FOR')
+    if ip1 not in ips_permeses and ip2 not in ips_permeses :
         missatge = ERROR_IP_NO_PERMESA_REPORT_PAGAMENT_ONLINE
-        txt = missatge.format(ip)
+        txt = missatge.format(ip1,ip2)
         tipus_de_missatge = tipusMissatge(missatge)
         logPagaments(txt, tipus_de_missatge)
         return HttpResponseServerError()

--- a/aula/apps/sortides/views.py
+++ b/aula/apps/sortides/views.py
@@ -1432,7 +1432,8 @@ def retornTransaccio(request,pk):
                     '194.224.159.57']  # ip's Banc Sabadell
     ip1 = request.META.get('REMOTE_ADDR')
     ip2 = request.META.get('HTTP_X_FORWARDED_FOR')
-    if ip1 not in ips_permeses and ip2 not in ips_permeses :
+    la_remota_o_la_forwarded_permesa = ip1 in ips_permeses or ip2 in ips_permeses
+    if not la_remota_o_la_forwarded_permesa:
         missatge = ERROR_IP_NO_PERMESA_REPORT_PAGAMENT_ONLINE
         txt = missatge.format(ip1,ip2)
         tipus_de_missatge = tipusMissatge(missatge)


### PR DESCRIPTION
Si el servidor on està allotjat el djAu disposa d'un proxy (p.e. Cloudflare), a l'hora de controlar les ip's d'origen en el retorn dels pagaments online, s'ha d'afegir la ip inclosa a "HTTP_X_FORWARDED_FOR"