### PR TITLE
Bug si nom de fitxer porta accents

### DIFF
--- a/aula/apps/missatgeria/views.py
+++ b/aula/apps/missatgeria/views.py
@@ -351,7 +351,7 @@ def EmailFamilies(request):
                 missatge = "Email a famílies no enviat. "+str(e)
                 messages.error(request, missatge)
             except Exception as e:
-                missatge = "Email a famílies no enviat, torneu a intentar-ho en uns minuts."
+                missatge = "Email a famílies no enviat, torneu a intentar-ho en uns minuts. "+str(e)
                 messages.error(request, missatge)
                 
             # envio al que ho envia:

--- a/aula/apps/relacioFamilies/notifica.py
+++ b/aula/apps/relacioFamilies/notifica.py
@@ -230,11 +230,17 @@ def pendentEmail(subject, body, from_email, bcc, attachments=None):
     bcc és una llista
     '''
     
+    import unicodedata
+    
     with transaction.atomic():
         ep=EmailPendent(subject=subject, message=body, fromemail=from_email, toemail=str(bcc))
         ep.save()
         if attachments:
             for f in attachments:
+                # Elimina accents del nom de fitxer
+                newname=unicodedata.normalize('NFKD',f.name).encode('ascii','ignore').decode('UTF-8')
+                if f.name!=newname:
+                    f.name=newname
                 file_instance = DocAttach(fitxer=f)
                 file_instance.email=ep
                 file_instance.save()


### PR DESCRIPTION
Corregeix error quan el nom de fitxer adjunt d'un email conté caràcters especials com els accents.
Només passava quan l'email es quedava en espera.