### PR TITLE
BugSerialize

### DIFF
--- a/aula/apps/missatgeria/views.py
+++ b/aula/apps/missatgeria/views.py
@@ -125,7 +125,7 @@ def enviaMissatgeTutors( request ):
             if len( tutors ) == 0:
                 formAlumne._errors.setdefault(NON_FIELD_ERRORS, []).append(  u'''No trobat el tutor d'aquest alumne. Cal trucar al cap d'estudis.'''  )
             else:
-                request.session['consergeria_darrera_data'] = data
+                request.session['consergeria_darrera_data'] = data.strftime( '%d/%m/%Y' )
                 txt2 = msg.text_missatge
                 txt = CONSERGERIA_A_TUTOR
                 msg.text_missatge = txt
@@ -154,11 +154,11 @@ def enviaMissatgeTutors( request ):
                 return HttpResponseRedirect( url )  
     else:
         
-        consergeria_darrera_data = request.session.get( 'consergeria_darrera_data' , datetime.today() )
+        consergeria_darrera_data = request.session.get( 'consergeria_darrera_data' , datetime.today().strftime( '%d/%m/%Y' ) )
         formAlumne = triaAlumneSelect2Form( )
         formData = dataForm(  label='Data', 
                               help_text=u'El text del missatge començarà per: Amb data ______, ' ,
-                              initial = {'data': consergeria_darrera_data })        
+                              initial = {'data': datetime.strptime(consergeria_darrera_data, '%d/%m/%Y') })        
         formData.fields['data'].required = True
         msgForm = msgFormF(  )
     

--- a/aula/utils/middleware.py
+++ b/aula/utils/middleware.py
@@ -56,13 +56,13 @@ class timeOutMiddleware:
     def process_request(self, request):
         if request.user.is_authenticated:
             if 'lastRequest' in request.session:            
-                elapsedTime = datetime.datetime.now() - request.session['lastRequest']
+                elapsedTime = datetime.datetime.now() - datetime.datetime.strptime(request.session['lastRequest'], '%c')
                 maxim_timeout = calculate_my_time_off(request.user)
                 if elapsedTime.seconds > maxim_timeout:
                     del request.session['lastRequest'] 
                     logout(request)
 
-            request.session['lastRequest'] = datetime.datetime.now()
+            request.session['lastRequest'] = datetime.datetime.now().strftime( '%c' )
         else:
             if 'lastRequest' in request.session:
                 del request.session['lastRequest'] 


### PR DESCRIPTION
Corregit error en opció missatge a tutors.
"Object of type date is not JSON serializable".

El serializer per defecte de Django 5 no funciona bé amb tipus complexes. 
Faltava adaptar uns casos, em sembla que ja hi són tots.
Haurem de crear un serializer propi, de moment he fet una solució d'emergència.
