### PR TITLE
Canvis a importació d'alumnes

### DIFF
--- a/aula/apps/extEsfera/sincronitzaEsfera.py
+++ b/aula/apps/extEsfera/sincronitzaEsfera.py
@@ -78,7 +78,7 @@ def sincronitza(f, user = None):
     rows = list(wb2.active.rows)
     col_indexs = {n: cell.value for n, cell in enumerate(rows[5])
                    if cell.value in colnames} # Començar a la fila 6, les anteriors són brossa
-    nivells = set()
+    cursos = set()
     for row in rows[6:max_row - 1]:  # la darrera fila també és brossa
         a = Alumne()
         a.ralc = ''
@@ -242,12 +242,12 @@ def sincronitza(f, user = None):
                 a.data_alta = alumneDadesAnteriors.data_alta
                 
         a.save()
-        nivells.add(a.grup.curs.nivell)
+        cursos.add(a.grup.curs)
     #
     # Baixes:
     #
     # Els alumnes de Saga no s'han de tenir en compte per fer les baixes
-    AlumnesDeSaga = Alumne.objects.exclude(grup__curs__nivell__in=nivells)
+    AlumnesDeSaga = Alumne.objects.exclude(grup__curs__in=cursos)
     # Es canvia estat PRC a ''. No modifica DEL ni MAN
     AlumnesDeSaga.filter( estat_sincronitzacio__exact = 'PRC' ).update(estat_sincronitzacio='')
     

--- a/aula/apps/extSaga/sincronitzaSaga.py
+++ b/aula/apps/extSaga/sincronitzaSaga.py
@@ -74,7 +74,7 @@ def sincronitza(f, user = None):
     trobatRalc = False
 
     f.seek(0)
-    nivells = set()
+    cursos = set()
     for row in reader:
         info_nAlumnesLlegits+=1
         a=Alumne()
@@ -250,13 +250,13 @@ def sincronitza(f, user = None):
 
 
         a.save()
-        nivells.add(a.grup.curs.nivell)
+        cursos.add(a.grup.curs)
     #
     # Baixes:
     #
 
     # Els alumnes d'Esfer@ no s'han de tenir en compte per fer les baixes
-    AlumnesDeEsfera = Alumne.objects.exclude(grup__curs__nivell__in=nivells)
+    AlumnesDeEsfera = Alumne.objects.exclude(grup__curs__in=cursos)
     # Es canvia estat PRC a ''. No modifica DEL ni MAN
     AlumnesDeEsfera.filter( estat_sincronitzacio__exact = 'PRC' ).update(estat_sincronitzacio='')
     


### PR DESCRIPTION
Permet alumnes del mateix nivell des d'Esfer@ i Saga.
A partir d'aquest curs 2024-2025, hi ha cursos d'alumnes de formació professional que es gestionen des d'Esfer@ i altres cursos des de Saga.
El sistema d'importació actual de Djau implica que els nivells gestionats des d'Esfer@ han de ser diferents dels de Saga.
Aquest pull request permet que es gestionin els mateixos nivells, ara fa la diferenciació segons el curs.
