### PR TITLE
Esfera saga

### DIFF
--- a/aula/utils/menu.py
+++ b/aula/utils/menu.py
@@ -258,8 +258,8 @@ def calcula_menu( user , path, sessioImpersonada ):
                   (
                       ("Sincronitza", 'administracio__sincronitza__blanc', di, None, 
                         (
-                          ("Alumnes ESO/BAT", 'administracio__sincronitza__esfera', di , None  ),
-                          ("Alumnes Cicles", 'administracio__sincronitza__saga', di, None),
+                          ("Alumnes Esfer@", 'administracio__sincronitza__esfera', di , None  ),
+                          ("Alumnes SAGA", 'administracio__sincronitza__saga', di, None),
                           ("Dades addicionals alumnat", 'administracio__sincronitza__dades_addicionals', di, None),
                           ("Preinscripció", 'administracio__sincronitza__preinscripcio', di , None  ),
                           ("HorarisKronowin", 'administracio__sincronitza__kronowin', di , None  ),

--- a/docs/manuals/parametritzacions.txt
+++ b/docs/manuals/parametritzacions.txt
@@ -276,6 +276,16 @@ ParametreSaga.autoRalc
     Genera RALC per als alumnes que no tenen, p.ex: CAM i CIS.
     El RALC es crea amb el prefix+DNI
 
+ParametreSaga.CursosManuals
+    Per solucionar el conflicte de cursos compartits Esfer@-SAGA:
+    Es pot definir, a Extsaga / Paràmetres Saga, un paràmetre 'CursosManuals' amb la llista de cursos en què els alumnes
+    quedaran insertats com a manuals (MAN).
+    Aquesta llista inclou els noms dels cursos, segons el camp 'nom_curs'. p.ex: ['1'], ['1', '2'], ['2', '4'], ...
+    Si existeix la llista, manté els alumnes afegits d'aquests cursos en estat 'MAN', així la importació
+    des d'esfer@ no donarà de baixa els alumnes.
+    Si no hi ha llista (o no existeix el paràmetre) es comporta com sempre, no els marca 'MAN' i dona de baixa els alumnes
+    que no surten al fitxer.
+
 ExtEsfera
 
 ParametreEsfera.grups estatics


### PR DESCRIPTION
Seguint la idea de tenir els alumnes de Saga en estat Manual, he automatitzat el procés. Aquest curs afecta els alumnes de primer, però el curs vinent afectarà també els de segon.
Mitjançant un paràmetre a Extsaga / Paràmetres Saga, es pot decidir el comportament.
Paràmetre 'AlumnesManuals' amb valor 'True' o 'False':
Si True manté els alumnes afegits de Saga en estat 'MAN', d'aquesta manera la importació des d'esfer@ no donarà de baixa els alumnes. Els alumnes que no surten al fitxer es mantenen intactes, per tant, no altera els alumnes d'esfera.
Si False (o no existeix el paràmetre) es comporta com sempre, no els marca 'MAN' i dona de baixa els alumnes que no surten al fitxer.

Si el paràmetre és True, les baixes d'alumnes s'haurien de fer manuals, suposo que no n'hi haurà gaires.
