### PR TITLE
Professor no es té en compte en carta absentisme

### DIFF
--- a/aula/apps/tutoria/views.py
+++ b/aula/apps/tutoria/views.py
@@ -2471,9 +2471,9 @@ def avisTutorCartaPerFaltes(professor):
             carta, created = CartaAbsentisme.objects.get_or_create(alumne=alumne,
                                                                    data_carta=None,
                                                                    carta_numero=darrera_carta_n,
-                                                                   professor=professor,
+                                                                   #professor=professor,
                                                                    defaults={'faltes_fins_a_data': datetime(1999, 1, 1),
-                                                                             'nfaltes': 0, 'tipus_carta': ''})
+                                                                             'nfaltes': 0, 'tipus_carta': '', 'professor':professor})
             if created:
                 carta.carta_numero += 1
                 carta.save()


### PR DESCRIPTION
Hi ha un error al codi on es generen les cartes d'absentisme. Es tenia en compte el professor/a tutor/a que té l'alumne/a.
Per tant si l'alumne/a té més d'un professor tutor/a, es van generant cartes cada cop que un d'ells passa llísta.
Amb aquest PR ja no es té en compte el professor/a tutor/a.