### PR TITLE
Afegir classe form-class

### DIFF
--- a/aula/apps/tutoria/forms.py
+++ b/aula/apps/tutoria/forms.py
@@ -8,7 +8,7 @@ from django.forms.widgets import Widget
 from django_select2.forms import ModelSelect2Widget
 
 class elsMeusAlumnesTutoratsEntreDatesForm( forms.Form ):
-    grup = forms.ChoiceField(   )
+    grup = forms.ChoiceField(  help_text=u'Tria un grup per veure dades del grup.')
     dataDesDe =  forms.DateField(label=u'Data des de', 
                                        initial=datetime.date.today,
                                        required = False, 

--- a/aula/apps/tutoria/views.py
+++ b/aula/apps/tutoria/views.py
@@ -48,7 +48,7 @@ from aula.apps.horaris.models import FranjaHoraria, Horari
 from aula.apps.incidencies.models import Incidencia, Expulsio
 from aula.utils.tools import llista, unicode
 from aula.apps.avaluacioQualitativa.forms import alumnesGrupForm
-from aula.utils.forms import dataForm, ckbxForm, choiceForm
+from aula.utils.forms import afegeigFormControlClass, dataForm, ckbxForm, choiceForm
 from aula.apps.avaluacioQualitativa.models import RespostaAvaluacioQualitativa
 import json as simplejson
 from django.core import serializers
@@ -408,7 +408,8 @@ def novaActuacio(request):
         formset.append( formActuacio )
 
 
-
+    afegeigFormControlClass(formActuacio)
+    
     return render(
                 request,
                 'formset.html',
@@ -1268,6 +1269,7 @@ def elsMeusAlumnesTutoratsEntreDates(request):
     else:
         form = elsMeusAlumnesTutoratsEntreDatesForm( grups = possibles_grups )
 
+        afegeigFormControlClass(form)
     return render(
                 request,
                 'form.html',

--- a/aula/utils/forms.py
+++ b/aula/utils/forms.py
@@ -48,6 +48,11 @@ class choiceForm(forms.Form):
         self.fields['opcio'].help_text = self.help_text          
 
 
+def afegeigFormControlClass(unForm):
+    for field in unForm.base_fields:
+        unForm.base_fields[field].widget.attrs.update({'class': 'form-control'})
+
+
 class initDBForm(forms.Form):
      
     confirma = forms.BooleanField( label=u'Confirma inicialització',required = True,


### PR DESCRIPTION
### Motivació

* Closes #297 

### En aquesta PR

Es crea una utilitat per facilitar afegir `form-class` de bootstrap als forms. Quan trobem forms que no ho tinguin només cal invocar la funció tal com es veu als canvis d'aquest commit:



<img width="1214" alt="Captura de pantalla 2025-01-28 a les 17 33 33" src="https://github.com/user-attachments/assets/37563d63-f627-4ebf-b584-af894617a390" />
