### PR TITLE
Modificar el comparador per trobar elements "que continguin"

### DIFF
--- a/aula/apps/sortides/filters.py
+++ b/aula/apps/sortides/filters.py
@@ -1,10 +1,13 @@
 import django_filters
 from aula.apps.sortides.models import Sortida
-from django.apps import apps 
+from django.apps import apps
 from django.db.models import Q
 
 
 class SortidaFilter(django_filters.FilterSet):
+    """
+    Filtre per a la llista de sortides o pagaments.
+    """
 
     professor = django_filters.ModelChoiceFilter(
         queryset=None,  # Temporarily set to None
@@ -12,12 +15,24 @@ class SortidaFilter(django_filters.FilterSet):
         label="Professor responsable o acompanyant",
     )
 
+    titol = django_filters.CharFilter(lookup_expr="icontains", label="Títol")
+    ambit = django_filters.CharFilter(lookup_expr="icontains", label="Àmbit")
+    ciutat = django_filters.CharFilter(lookup_expr="icontains", label="Ciutat")
+    mitja_de_transport = django_filters.CharFilter(
+        lookup_expr="icontains", label="Mitjà de transport"
+    )
+    empresa_de_transport = django_filters.CharFilter(
+        lookup_expr="icontains", label="Empresa de transport"
+    )
+
     # init
     def __init__(self, *args, tipus=None, **kwargs):
         super(SortidaFilter, self).__init__(*args, **kwargs)
 
-        Professor = apps.get_model('usuaris', 'Professor')  # Dynamically get the model
-        self.filters['professor'].queryset = Professor.objects.all()  # Set queryset dynamically
+        Professor = apps.get_model("usuaris", "Professor")
+        self.filters["professor"].queryset = (
+            Professor.objects.all()
+        )  # Set queryset dynamically
 
         if tipus == "P":
             # remove 'tipus' from filter fields
@@ -34,11 +49,14 @@ class SortidaFilter(django_filters.FilterSet):
             "ambit",
             "ciutat",
             "mitja_de_transport",
-            "empresa_de_transport",            
+            "empresa_de_transport",
         ]
 
     @property
     def form(self):
+        """
+        Sobreescric el form per tal d'afegir la classe 'form-control' als widgets
+        """
         form = super().form
         for field in form.fields.values():
             field.widget.attrs.update({"class": "form-control"})
@@ -46,10 +64,10 @@ class SortidaFilter(django_filters.FilterSet):
 
     def filter_by_professor(self, queryset, name, value):
         """
-        Filters Sortida by a Professor instance, checking both `professor_que_proposa` 
+        Filters Sortida by a Professor instance, 
+        checking both `professor_que_proposa`
         and `professors_responsables` fields.
         """
         return queryset.filter(
-            Q(professor_que_proposa=value) | 
-            Q(professors_responsables=value)
+            Q(professor_que_proposa=value) | Q(professors_responsables=value)
         ).distinct()


### PR DESCRIPTION
He modificat el comparador per tal de fer servir `icontains` en comptes d' `=`:

```sql
SELECT 
  DISTINCT "sortides_sortida"."id", 
  "sortides_sortida"."estat", 
  "sortides_sortida"."estat_sincronitzacio", 
  -- ...
FROM 
  "sortides_sortida" 
WHERE 
  (
    "sortides_sortida"."tipus" = A 
    AND "sortides_sortida"."titol" LIKE % hola % ESCAPE '\') -- <-- AQUÍ
```