### PR TITLE
Modificat càlcul absentisme

### DIFF
--- a/aula/apps/presencia/rpt_faltesAssistenciaEntreDatesProfessor.py
+++ b/aula/apps/presencia/rpt_faltesAssistenciaEntreDatesProfessor.py
@@ -26,9 +26,9 @@ def faltesAssistenciaEntreDatesProfessorRpt(
     q_darrer_dia = Q(impartir__dia_impartir = dataFinsA ) & Q(impartir__horari__hora__hora_fi__lte = horaFinsA.hora_fi)
     q_hores = q_primer_dia | q_mig | q_darrer_dia
     
-    controls = ControlAssistencia.objects.filter( q_grup & q_assignatures & q_hores & q_professor )
+    controls_grup = ControlAssistencia.objects.filter( q_grup & q_assignatures & q_hores & q_professor )
     
-    alumnes = AlumneNomSentit.objects.filter( controlassistencia__pk__in = controls.values_list('pk', flat=True)
+    alumnes = AlumneNomSentit.objects.filter( controlassistencia__pk__in = controls_grup.values_list('pk', flat=True)
                                       ).distinct()
     
     report = []
@@ -92,6 +92,7 @@ def faltesAssistenciaEntreDatesProfessorRpt(
     taula.capceleres.append( capcelera )
 
     taula.fileres = []
+    controls = ControlAssistencia.objects.filter( q_assignatures & q_hores )
     
     for alumne in  alumnes:
                 


### PR DESCRIPTION
Apartats "Els meus alumnes" i "LListat entre dates": En cas de grups desdoblats o matèries amb professorat diferent segons l'hora, el càlcul dels totals no corresponia a les hores globals. El càlcul es feia per grup, professorat i assignatura, no es tenien en compte les hores fetes per l'alumne amb altre professorat de la matèria o en altres grups de desdoblament.

S'ha modificat per fer el càlcul de les hores de l'alumne en global de la matèria, d'aquesta manera es té la informació correcta sobre l'assistència de l'alumne a l'assignatura.