### PR TITLE
Filtre de data inici i fi + crispy

### DIFF
--- a/aula/apps/sortides/filters.py
+++ b/aula/apps/sortides/filters.py
@@ -1,7 +1,14 @@
-import django_filters
-from aula.apps.sortides.models import Sortida
+"""Filtre per a la llista de sortides o pagaments."""
+
 from django.apps import apps
 from django.db.models import Q
+import django_filters
+
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Layout, Div, Field, Submit
+
+from aula.apps.sortides.models import Sortida
+from aula.utils.widgets import DateTextImput
 
 
 class SortidaFilter(django_filters.FilterSet):
@@ -18,6 +25,9 @@ class SortidaFilter(django_filters.FilterSet):
     titol = django_filters.CharFilter(lookup_expr="icontains", label="Títol")
     ambit = django_filters.CharFilter(lookup_expr="icontains", label="Àmbit")
     ciutat = django_filters.CharFilter(lookup_expr="icontains", label="Ciutat")
+    tipus = django_filters.ChoiceFilter(
+        choices=Sortida.TIPUS_ACTIVITAT_CHOICES, label="Tipus"
+    )
     mitja_de_transport = django_filters.CharFilter(
         lookup_expr="icontains", label="Mitjà de transport"
     )
@@ -25,8 +35,23 @@ class SortidaFilter(django_filters.FilterSet):
         lookup_expr="icontains", label="Empresa de transport"
     )
 
+    data_inici_desde = django_filters.DateFilter(
+        field_name="data_inici",
+        lookup_expr="gte",
+        label="Data d'inici (des de)",
+        widget=DateTextImput(),
+    )
+
+    data_inici_fins = django_filters.DateFilter(
+        field_name="data_inici",
+        lookup_expr="lte",
+        label="Data d'inici (fins a)",
+        widget=DateTextImput(),
+    )
+
     # init
     def __init__(self, *args, tipus=None, **kwargs):
+        """Init: set queryset and other settings"""
         super(SortidaFilter, self).__init__(*args, **kwargs)
 
         Professor = apps.get_model("usuaris", "Professor")
@@ -34,12 +59,53 @@ class SortidaFilter(django_filters.FilterSet):
             Professor.objects.all()
         )  # Set queryset dynamically
 
+        extra_divs = [
+            Div(Field("ambit", css_class="form-control"), css_class="col-lg-4"),
+            Div(Field("tipus", css_class="form-control"), css_class="col-lg-4"),
+        ]
         if tipus == "P":
             # remove 'tipus' from filter fields
             self.filters.pop("tipus")
             self.filters.pop("ciutat")
 
-    class Meta:
+        # Crispy Forms Helper
+        self.helper = FormHelper()
+        self.helper.form_method = "GET"
+        self.helper.form_class = "form-inline"
+        self.helper.layout = self.helper.layout = Layout(
+            Div(
+                *extra_divs,
+                Div(Field("subtipus", css_class="form-control"), css_class="col-lg-4"),
+                Div(Field("estat", css_class="form-control"), css_class="col-lg-4"),
+                Div(Field("titol", css_class="form-control"), css_class="col-lg-4"),
+                Div(Field("ciutat", css_class="form-control"), css_class="col-lg-4"),
+                Div(
+                    Field("mitja_de_transport", css_class="form-control"),
+                    css_class="col-lg-4",
+                ),
+                Div(
+                    Field("empresa_de_transport", css_class="form-control"),
+                    css_class="col-lg-4",
+                ),
+                css_class="row",
+            ),
+            Div(
+                Div(
+                    Field("data_inici_desde", css_class="form-control"),
+                    css_class="col-lg-4",
+                ),
+                Div(
+                    Field("data_inici_fins", css_class="form-control"),
+                    css_class="col-lg-4",
+                ),
+                css_class="row",
+            ),
+            Submit("submit", "Filtrar", css_class="btn btn-primary"),
+        )
+
+    class Meta:  # pylint: disable=too-few-public-methods
+        """Configuració del filtre."""
+
         model = Sortida
         fields = [
             "estat",
@@ -50,6 +116,8 @@ class SortidaFilter(django_filters.FilterSet):
             "ciutat",
             "mitja_de_transport",
             "empresa_de_transport",
+            "data_inici_desde",
+            "data_inici_fins",
         ]
 
     @property
@@ -64,7 +132,7 @@ class SortidaFilter(django_filters.FilterSet):
 
     def filter_by_professor(self, queryset, name, value):
         """
-        Filters Sortida by a Professor instance, 
+        Filters Sortida by a Professor instance,
         checking both `professor_que_proposa`
         and `professors_responsables` fields.
         """

--- a/aula/apps/sortides/views.py
+++ b/aula/apps/sortides/views.py
@@ -305,9 +305,7 @@ def sortidesAllList(request, tipus=None):
     url = r"{0}{1}".format(
         settings.URL_DJANGO_AULA, reverse("sortides__sortides__ical")
     )
-    
-    afegeigFormControlClass(filter.form)
-    
+        
     return render(
         request,
         "table2.html",

--- a/aula/settings_dir/common.py
+++ b/aula/settings_dir/common.py
@@ -194,8 +194,12 @@ INSTALLED_APPS_DJANGO = [
     'rest_framework',
     'rest_framework_simplejwt',
     'django_gsuite_email',
+    'crispy_forms',
+    'crispy_bootstrap3',
 ]
-    
+
+CRISPY_TEMPLATE_PACK = "bootstrap3"
+
 INSTALLED_APPS_AULA = [
     # Uncomment the next line to enable admin documentation:
     # 'django.contrib.admindocs',

--- a/aula/templates/table2.html
+++ b/aula/templates/table2.html
@@ -3,6 +3,7 @@
 {% load django_tables2 %}
 {% load static %}
 {% load humanize %}
+{% load crispy_forms_tags %}
 
 {% block extrahead %}
 <link rel="stylesheet" href="{{STATIC_URL}}BOOTABLE2/css/estil.css?ver=1" />
@@ -14,8 +15,9 @@
 
 	{% if filter %}
 	<form method="get">
-        {{ filter.form.as_p }}
-        <input class="btn btn-sm btn-primary" type="submit" />
+		{% csrf_token %}
+		{% crispy filter.form filter.helper %}
+        
     </form>
 	{% endif %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,5 @@ django-filter
 qrcode
 djangorestframework-simplejwt
 djau-gsuite-email
+crispy-bootstrap3==2024.1
+django-crispy-forms==2.3


### PR DESCRIPTION
### Motivacioó

* Closes #308 

### En aquesta PR

* Afegir filtres per dates inici fi.
* Afegir [django-crispy-forms](https://django-crispy-forms.readthedocs.io/en/latest/)

### Notes

Fa molts anys que en projectes django utilitzo [django-crispy-forms](https://django-crispy-forms.readthedocs.io/en/latest/) i és una llibreria que m'agrada molt perquè permet d'una manera molt declarativa determinar la disposició dels camps dels formularis i és compatible amb bootstrap.

En aquesta PR introdueixo la llibreria al djau. Llavors m'agradaria compatir-ho i conèixer la vostra opinió, si us va bé que la posem o si creieu que no val la pena. cc: @amorilla @juaky 

<img width="1264" alt="Captura de pantalla 2025-02-28 a les 20 39 09" src="https://github.com/user-attachments/assets/9ba2bed1-209d-4db6-947a-4bd9ba382a83" />

