### PR TITLE
Corregits errors

### DIFF
--- a/aula/apps/alumnes/admin.py
+++ b/aula/apps/alumnes/admin.py
@@ -56,6 +56,7 @@ class AlumneAdmin(admin.ModelAdmin):
     list_filter = ["grup"]
     list_display = ["cognoms", "nom", "grup"]
     search_fields = ["cognoms", "nom"]
+    readonly_fields = ('responsable_preferent',)
     # DEPRECATED vvv
     exclude = [
         "correu_tutors",

--- a/aula/apps/usuaris/views.py
+++ b/aula/apps/usuaris/views.py
@@ -49,6 +49,7 @@ from aula.apps.usuaris.models import (
     ResponsableUser,
     User2Professor,
     User2Responsable,
+    User2Alumne,
 )
 from aula.apps.usuaris.tables2_models import HorariProfessorTable
 from aula.apps.usuaris.tools import enviaOneTimePasswd, testEmail
@@ -59,7 +60,7 @@ from aula.utils.tools import getClientAdress, unicode
 
 
 @login_required
-@group_required(["professors", "consergeria", "tpvs"])
+@group_required(["professors", "consergeria", "tpvs", 'administratius', 'secretaria'])
 def canviDadesUsuari(request):
     credentials = tools.getImpersonateUser(request)
     (user, _) = credentials
@@ -394,7 +395,7 @@ def loginUser(request):
                         if User2Responsable(user):
                             user.responsable.motiu_bloqueig = ""
                             user.responsable.save()
-                        elif not User2Professor(user):
+                        elif User2Alumne(user):
                             user.alumne.motiu_bloqueig = ""
                             user.alumne.save()
                         return HttpResponseRedirect(url_next)


### PR DESCRIPTION
Solucionat el problema dels usuaris del PAS que no podien accedir. 

Des d'admin site obligava a introduir responsable_preferent de l'alumne. A l'espera d'una solució millor, de moment no es permet modificar aquest atribut a l'admin site. El professor/tutor de l'alumne podrà modificar-lo des del portal.