### PR TITLE
Update packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ On Ubuntu Server 24.04 LTS:
 sudo apt-get update
 sudo apt-get install python3 python3-venv python3-dev git
 sudo apt-get install python3-lxml python3-libxml2 libxml2-dev libxslt-dev lib32z1-dev
+sudo apt-get install libgl1 libglib2.0-0t64
 mkdir djau
 cd djau
 git clone --single-branch --branch master https://github.com/ctrl-alt-d/django-aula.git django-aula

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ make start
 Quick demo
 =========
 
-On Ubuntu Server 20.04/22.04 LTS 64 bits:
+On Ubuntu Server 24.04 LTS:
 
 ```bash
 sudo apt-get update

--- a/aula/apps/relacioFamilies/forms.py
+++ b/aula/apps/relacioFamilies/forms.py
@@ -1,4 +1,3 @@
-import imghdr
 import io
 import os
 
@@ -13,7 +12,7 @@ from aula.utils.widgets import DataHoresAlumneAjax
 
 
 def tipusFotoOK(foto):
-    if foto and "image/{0}".format(imghdr.what(foto)) not in CUSTOM_TIPUS_MIME_FOTOS:
+    if foto and foto.content_type not in CUSTOM_TIPUS_MIME_FOTOS:
         message = "Tipus de fitxer no vàlid. Formats permesos: {0}".format(
             CUSTOM_TIPUS_MIME_FOTOS
         ).replace("image/", "")

--- a/aula/apps/relacioFamilies/forms.py
+++ b/aula/apps/relacioFamilies/forms.py
@@ -12,7 +12,7 @@ from aula.utils.widgets import DataHoresAlumneAjax
 
 
 def tipusFotoOK(foto):
-    if foto and foto.content_type not in CUSTOM_TIPUS_MIME_FOTOS:
+    if foto and hasattr(foto, 'content_type') and foto.content_type not in CUSTOM_TIPUS_MIME_FOTOS:
         message = "Tipus de fitxer no vàlid. Formats permesos: {0}".format(
             CUSTOM_TIPUS_MIME_FOTOS
         ).replace("image/", "")

--- a/aula/apps/usuaris/forms.py
+++ b/aula/apps/usuaris/forms.py
@@ -1,5 +1,4 @@
 # This Python file uses the following encoding: utf-8
-import imghdr
 import io
 import os
 
@@ -53,7 +52,7 @@ class CanviDadesAddicionalsUsuari(ModelForm):
         foto = self.cleaned_data["foto"]
         if (
             foto
-            and "image/{0}".format(imghdr.what(foto)) not in CUSTOM_TIPUS_MIME_FOTOS
+            and foto.content_type not in CUSTOM_TIPUS_MIME_FOTOS
         ):
             message = "Tipus de fitxer no vàlid. Formats permesos: {0}".format(
                 CUSTOM_TIPUS_MIME_FOTOS

--- a/aula/apps/usuaris/forms.py
+++ b/aula/apps/usuaris/forms.py
@@ -52,7 +52,7 @@ class CanviDadesAddicionalsUsuari(ModelForm):
         foto = self.cleaned_data["foto"]
         if (
             foto
-            and foto.content_type not in CUSTOM_TIPUS_MIME_FOTOS
+            and hasattr(foto, 'content_type') and foto.content_type not in CUSTOM_TIPUS_MIME_FOTOS
         ):
             message = "Tipus de fitxer no vàlid. Formats permesos: {0}".format(
                 CUSTOM_TIPUS_MIME_FOTOS

--- a/aula/apps/usuaris/views.py
+++ b/aula/apps/usuaris/views.py
@@ -86,7 +86,7 @@ def canviDadesUsuari(request):
             )
             formDadesAddicionals.fields["foto"].label = "Foto"
 
-        if formUsuari.is_valid():
+        if formUsuari.is_valid() and (not professor or formDadesAddicionals.is_valid()):
             # Verifica si domini correcte
             errors = {}
             email = formUsuari.cleaned_data["email"]

--- a/aula/settings_local.sample
+++ b/aula/settings_local.sample
@@ -92,7 +92,7 @@ SECRET_KEY = 'j*y^6816ynk5$phos1y*sf$)3o#m(1^u-j63k712keu4fjh$lc'
 CUSTOM_RESERVES_API_KEY = 'sxxxxxxm'
 
 # Path de datos privados
-PRIVATE_STORAGE_ROOT ='/opt/djau-dades-privades-2022/'
+PRIVATE_STORAGE_ROOT ='/opt/djau-dades-privades-2025/'
 CUSTOM_CODI_COMERÇ = 'xxxxxx'
 CUSTOM_KEY_COMERÇ = 'xxxxxx'
 

--- a/docs/Wiki/README.md
+++ b/docs/Wiki/README.md
@@ -20,7 +20,7 @@ El Proyecto es Open-source, y aquí se encuentra su repositorio Git: [https://gi
 * [Características](caracteristicas.md)
 * [Funcionalidades](funcionalidades.md)
 * [Instalación](instalacion-2/README.md)
-  * [Instalación en Ubuntu Server 20.04/22.04 LTS](instalacion-2/instalacion.md)
+  * [Instalación en Ubuntu Server 24.04 LTS o Debian 13](instalacion-2/instalacion.md)
 * [Manual del Administrador](manual-de-uso/README.md)
   * [Primer Inicio](manual-de-uso/primer-inicio.md)
   * [Carga Inicial de datos](manual-de-uso/carga-inicial-de-datos/README.md)

--- a/docs/Wiki/SUMMARY.md
+++ b/docs/Wiki/SUMMARY.md
@@ -4,7 +4,7 @@
 * [Caracteristicas](caracteristicas.md)
 * [Funcionalidades](funcionalidades.md)
 * [Instalación](instalacion-2/README.md)
-  * [Instalación en Ubuntu Server 20.04/22.04 LTS](instalacion-2/instalacion.md)
+  * [Instalación en Ubuntu Server 24.04 LTS o Debian 13](instalacion-2/instalacion.md)
 * [Manual del Administrador](manual-de-uso/README.md)
   * [Primer Inicio](manual-de-uso/primer-inicio.md)
   * [Carga Inicial de datos](manual-de-uso/carga-inicial-de-datos/README.md)

--- a/docs/Wiki/instalacion-2/README.md
+++ b/docs/Wiki/instalacion-2/README.md
@@ -8,5 +8,5 @@ description: >-
 
 Django-Aula puede instalarse en cualquier Distribución Linux que sea capaz de ejecutar Python 3.5 o superior sin demasiados problemas, pero recomendamos que se instale sobre Ubuntu Server. Si has instalado satisfactoriamente la aplicación en tu distribución favorita no dudes en colaborar en este libro con el proceso que has seguido, estaremos muy agradecidos.
 
-[Instalación en Ubuntu Server 20.04/22.04 LTS](instalacion.md)
+[Instalación en Ubuntu Server 24.04 LTS o Debian 13](instalacion.md)
 

--- a/docs/Wiki/instalacion-2/instalacion.md
+++ b/docs/Wiki/instalacion-2/instalacion.md
@@ -1,4 +1,4 @@
-# Instalación en Ubuntu Server 20.04 LTS / 22.04 LTS / 24.04 LTS
+# Instalación en Ubuntu 24.04 LTS o Debian 13
 
 > **Atención:**  Todas las instrucciones de este documento se deben ejecutar con permisos elevados
 
@@ -12,13 +12,19 @@ apt-get upgrade
 apt-get install python3 python3-venv libxml2-dev libxslt-dev python3-lxml python3-libxml2 python3-dev lib32z1-dev git
 ```
 
+**En Debian 13**
+
+```bash
+apt-get install libgl1 libglib2.0-0t64
+```
+
 Entre otras cosas se ha instalado el paquete **python-virtualenv** ya que la instalación la haremos sobre un entorno virtual de **Python**, si tienes curiosidad sobre esto, visita este [enlace](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/).
 
 Nos colocamos en el directorio donde instalaremos la aplicación y clonamos el repositorio del proyecto.
 
 ```bash
-cd /opt && sudo git clone https://github.com/ctrl-alt-d/django-aula.git djau2025 
-sudo chown -R :www-data djau2025  #opcionalmente se puede cambiar el propietario para no utilizar root.
+cd /opt && git clone https://github.com/ctrl-alt-d/django-aula.git djau2025 
+chown -R :www-data djau2025  #opcionalmente se puede cambiar el propietario para no utilizar root.
 cd djau2025
 ```
 
@@ -57,32 +63,13 @@ Antes de seguir con la aplicación, instalaremos Apache  y el módulo [wsgi](htt
 
 Además instalaremos la base de datos que usará django-aula y su conector python correspondiente, se recomienda instalar la aplicación sobre postgresql pero también es posible hacerlo sobre Mysql.
 
+
 **Postgresql  (recomenat):**
 
 ```bash
-apt-get install apache2 libapache2-mod-wsgi-py3 python3-psycopg2 postgresql
-```
-Para Ubuntu 20.04:
-
-```bash
-apt-get install postgresql-server-dev-12
-```
-Para Ubuntu 22.04:
-
-```bash
-apt-get install postgresql-server-dev-14
-```
-Para Ubuntu 24.04:
-
-```bash
-apt-get install postgresql-server-dev-16
+apt-get install apache2 libapache2-mod-wsgi-py3 python3-psycopg postgresql
 ```
 
-Package:
-
-```bash
-pip3 install wheel psycopg2
-```
 
 **Mysql (no recomenat):**
 
@@ -129,9 +116,9 @@ Actualmente las fotos de los alumnos.
 Para ello hay que crear una carpeta donde guardar esa información.
 
 ```bash
-mkdir -p /opt/djau-dades-privades-2022
-chmod 770 /opt/djau-dades-privades-2022
-chgrp www-data /opt/djau-dades-privades-2022 
+mkdir -p /opt/djau-dades-privades-2025
+chmod 770 /opt/djau-dades-privades-2025
+chgrp www-data /opt/djau-dades-privades-2025
 ```
 
 En el siguiente apartado se configura la variable `PRIVATE_STORAGE_ROOT` con el path escogido.
@@ -246,7 +233,7 @@ SECRET_KEY = 'j*y^6816ynk5$phos1y*sf$)3o#m(1^u-j63k712keu4fjh$lc'
 CUSTOM_RESERVES_API_KEY = 'sxxxxxxm'
 
 # Path de datos privados
-PRIVATE_STORAGE_ROOT ='/opt/djau-dades-privades-2022/'
+PRIVATE_STORAGE_ROOT ='/opt/djau-dades-privades-2025/'
 CUSTOM_CODI_COMERÇ = 'xxxxxx'
 CUSTOM_KEY_COMERÇ = 'xxxxxx'
 
@@ -417,7 +404,7 @@ locale -a
 Generación del locale adecuado para nuestro caso, por ejemplo:
 
 ```bash
-sudo locale-gen ca_ES.utf8
+/usr/sbin/locale-gen ca_ES.utf8
 ```
 
 El primer escenario es para servir la app por el puerto 80 \(http\),
@@ -552,9 +539,9 @@ El segundo escenario sirve la app por SSL \(https\)
 Una vez creado el VirtualHost,  deshabilitamos el Vhost que trae por defecto Apache para que no nos de problemas y reiniciamos el servidor web
 
 ```text
-djau@djau:# a2dissite 000-default.conf  # podría tener un nombre diferente
-djau@djau:# a2ensite djau.conf
-djau@djau:# a2ensite djau_ssl.conf
+djau@djau:# /usr/sbin/a2dissite 000-default.conf  # podría tener un nombre diferente
+djau@djau:# /usr/sbin/a2ensite djau.conf
+djau@djau:# /usr/sbin/a2ensite djau_ssl.conf
 djau@djau:# systemctl reload apache2
 ```
 

--- a/docs/Wiki/instalacion-2/instalacion.md
+++ b/docs/Wiki/instalacion-2/instalacion.md
@@ -9,13 +9,7 @@ El primer paso es preparar un entorno de desarrollo **[Python](https://www.pytho
 ```bash
 apt-get update
 apt-get upgrade
-apt-get install python3 python3-venv libxml2-dev libxslt-dev python3-lxml python3-libxml2 python3-dev lib32z1-dev git
-```
-
-**En Debian 13**
-
-```bash
-apt-get install libgl1 libglib2.0-0t64
+apt-get install python3 python3-venv libxml2-dev libxslt-dev python3-lxml python3-libxml2 python3-dev lib32z1-dev git libgl1 libglib2.0-0t64
 ```
 
 Entre otras cosas se ha instalado el paquete **python-virtualenv** ya que la instalación la haremos sobre un entorno virtual de **Python**, si tienes curiosidad sobre esto, visita este [enlace](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/).
@@ -67,16 +61,33 @@ Además instalaremos la base de datos que usará django-aula y su conector pytho
 **Postgresql  (recomenat):**
 
 ```bash
-apt-get install apache2 libapache2-mod-wsgi-py3 python3-psycopg postgresql
+apt-get install apache2 libapache2-mod-wsgi-py3 postgresql
 ```
 
 
 **Mysql (no recomenat):**
 
 ```bash
-apt-get install apache2 libapache2-mod-wsgi-py3 python3-mysqldb mysql-server libmysqlclient-dev pkg-config
-pip3 install wheel mysqlclient
+apt-get install apache2 libapache2-mod-wsgi-py3
 ```
+
+> ###### **Ubuntu**
+>
+>```bash
+>apt-get install mysql-server default-libmysqlclient-dev build-essential pkg-config
+>```
+>
+>###### **Debian**
+>
+>```bash
+>apt-get install mariadb-server default-libmysqlclient-dev build-essential pkg-config
+>```
+>
+>###### **Package**
+>
+>```bash
+>pip install mysqlclient
+>```
 
 Una vez elegido el motor de base de datos, hay que crear la base de datos de la aplicación, y crear un usuario que la pueda administrar.
 
@@ -84,7 +95,7 @@ Una vez elegido el motor de base de datos, hay que crear la base de datos de la 
 **Para Postgresql**
 
 ```text
-sudo su postgres
+su postgres
 psql
 CREATE DATABASE djau2025;
 CREATE USER djau2025 WITH PASSWORD 'XXXXXXXXXX';
@@ -97,7 +108,7 @@ exit
 **Para Mysql**
 
 ```
-sudo su
+su
 mysql
 CREATE DATABASE djau2025 CHARACTER SET utf8;
 CREATE USER 'djau2025'@'localhost' IDENTIFIED BY 'XXXXXXXX';

--- a/docs/Wiki/manual-de-uso/actualitza.md
+++ b/docs/Wiki/manual-de-uso/actualitza.md
@@ -27,6 +27,8 @@ systemctl stop apache2
 cd /opt/djau
 git pull
 source venv/bin/activate
+pip install --upgrade pip
+pip uninstall psycopg2 psycopg2-binary
 pip install --upgrade --no-cache-dir -r requirements.txt
 python manage.py migrate
 python manage.py collectstatic -c --no-input

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,8 @@ django-private-storage
 dnspython
 django-formtools
 invoke
-psycopg2-binary
+psycopg2-binary ; python_version <= '3.6'
+psycopg ; python_version > '3.6'
 django_select2
 djangorestframework
 markdown

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ lxml
 six
 django-debug-toolbar
 python-dateutil
-django-tables2 == 2.7.0 ; python_version <= '3.8'
-django-tables2 > 2.7.0 ; python_version > '3.8'
+django-tables2 == 2.7.0 ; python_version < '3.9'
+django-tables2 > 2.7.0 ; python_version >= '3.9'
 icalendar
 django-appconf
 Pillow
@@ -25,8 +25,8 @@ django-private-storage
 dnspython
 django-formtools
 invoke
-psycopg2-binary ; python_version <= '3.6'
-psycopg ; python_version > '3.6'
+psycopg2-binary ; python_version < '3.8'
+psycopg[binary] ; python_version >= '3.8'
 django_select2
 djangorestframework
 markdown
@@ -35,8 +35,8 @@ qrcode
 djangorestframework-simplejwt
 djau-gsuite-email
 crispy-bootstrap3==2024.1
-django-crispy-forms==2.0 ; python_version <= '3.8'
-django-crispy-forms==2.3 ; python_version > '3.8'
+django-crispy-forms==2.0 ; python_version < '3.9'
+django-crispy-forms==2.3 ; python_version >= '3.9'
 
 
 matplotlib


### PR DESCRIPTION
Deixa de fer servir el mòdul [imghdr](https://peps.python.org/pep-0594/#deprecated-modules) que desapareix a partir de python 3.13.
Substitueix psycopg2 pel nou [psycopg](https://pypi.org/project/psycopg/).
Actualitza documentació sobre la instal·lació.